### PR TITLE
feat: Add ynab_export_transactions_csv tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ This server provides **30+ specialized tools** organized into these categories:
 
 ### Transaction Management (10 tools)
 - `ynab_get_transactions` - Query transactions with advanced filtering
-- `ynab_export_transactions_csv` - Export all transactions as compact CSV (no row limit)
+- `ynab_export_transactions_csv` - Export account transactions as compact CSV (no row limit)
 - `ynab_create_transaction` - Create individual transactions
 - `ynab_update_transaction` - Update existing transactions
 - `ynab_delete_transaction` - Remove transactions
@@ -143,11 +143,12 @@ await tools.ynab_get_transactions({
   limit: 100
 });
 
-// Export all account transactions as CSV (no row limit)
+// Export account transactions as CSV (no row limit)
 await tools.ynab_export_transactions_csv({
   budget_id: "your-budget-id",
-  account_id: "account-id",
-  output_path: "/tmp/transactions.csv"  // optional — omit to get CSV string directly
+  account_id: "account-id",           // required
+  output_path: "/tmp/transactions.csv" // optional — omit to get CSV string directly
+  // all_accounts: true               // optional — ignore account_id, export everything
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -90,8 +90,9 @@ This server provides **30+ specialized tools** organized into these categories:
 - `ynab_get_accounts` - Retrieve account details, balances, and settings
 - `ynab_get_budget_month` - Get monthly budget data with category allocations
 
-### Transaction Management (9 tools)
+### Transaction Management (10 tools)
 - `ynab_get_transactions` - Query transactions with advanced filtering
+- `ynab_export_transactions_csv` - Export all transactions as compact CSV (no row limit)
 - `ynab_create_transaction` - Create individual transactions
 - `ynab_update_transaction` - Update existing transactions
 - `ynab_delete_transaction` - Remove transactions
@@ -140,6 +141,13 @@ await tools.ynab_get_transactions({
   budget_id: "your-budget-id",
   since_date: "2024-01-01",
   limit: 100
+});
+
+// Export all account transactions as CSV (no row limit)
+await tools.ynab_export_transactions_csv({
+  budget_id: "your-budget-id",
+  account_id: "account-id",
+  output_path: "/tmp/transactions.csv"  // optional — omit to get CSV string directly
 });
 ```
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -13,6 +13,7 @@ import { DeleteTransactionTool } from './transactions/deleteTransaction.js';
 import { BatchUpdateTransactionsTool } from './transactions/batchUpdateTransactions.js';
 import { CreateSplitTransactionTool } from './transactions/createSplitTransaction.js';
 import { UpdateTransactionSplitsTool } from './transactions/updateTransactionSplits.js';
+import { ExportTransactionsTool } from './transactions/exportTransactions.js';
 import { GetCategoriesTool } from './categories/getCategories.js';
 import { GetCategoryTool } from './categories/getCategory.js';
 import { UpdateCategoryBudgetTool } from './categories/updateCategoryBudget.js';
@@ -54,6 +55,7 @@ export function registerTools(client: YNABClient): Tool[] {
     new BatchUpdateTransactionsTool(client),
     new CreateSplitTransactionTool(client),
     new UpdateTransactionSplitsTool(client),
+    new ExportTransactionsTool(client),
     
     // Category tools
     new GetCategoriesTool(client),

--- a/src/tools/transactions/exportTransactions.ts
+++ b/src/tools/transactions/exportTransactions.ts
@@ -1,0 +1,128 @@
+import { z } from 'zod';
+import { writeFileSync } from 'fs';
+import { YnabTool } from '../base.js';
+import type { YnabTransactionsResponse } from '../../types/index.js';
+
+const ExportTransactionsInputSchema = z.object({
+  budget_id: z.string().describe('The ID of the budget to export transactions from'),
+  account_id: z.string().optional().describe('Filter to a specific account'),
+  since_date: z.string().optional().describe('Only return transactions on or after this date (YYYY-MM-DD)'),
+  output_path: z.string().optional().describe('If provided, write CSV to this file path and return a summary instead of the full CSV. Useful for large accounts.'),
+});
+
+type ExportTransactionsInput = z.infer<typeof ExportTransactionsInputSchema>;
+
+/**
+ * Escape a value for CSV output.
+ * Wraps in quotes if it contains commas, quotes, or newlines.
+ */
+function csvEscape(value: string | null | undefined): string {
+  if (value == null) return '';
+  const s = String(value);
+  if (s.includes(',') || s.includes('"') || s.includes('\n')) {
+    return '"' + s.replace(/"/g, '""') + '"';
+  }
+  return s;
+}
+
+const CSV_HEADERS = [
+  'date', 'amount', 'payee_name', 'category', 'cleared', 'approved',
+  'id', 'memo', 'flag_color', 'transfer_account_id', 'import_id',
+];
+
+/**
+ * Export all transactions for a budget or account as a compact CSV.
+ *
+ * Returns a flat CSV string with one row per transaction, amounts in dollars
+ * (not milliunits), suitable for direct comparison with bank statement CSVs.
+ * No artificial row limit — returns everything the YNAB API provides.
+ *
+ * If output_path is provided, writes the CSV to disk and returns a summary
+ * object instead of the full CSV string (useful for very large accounts).
+ */
+export class ExportTransactionsTool extends YnabTool {
+  name = 'ynab_export_transactions_csv';
+  description = 'Export all transactions for a budget or account as a compact CSV string. Returns flat rows with amounts in dollars — much smaller than the JSON format. Optionally writes to a file. No row limit.';
+  inputSchema = ExportTransactionsInputSchema;
+
+  async execute(args: unknown): Promise<string | {
+    path: string;
+    count: number;
+    date_range: { from: string; to: string };
+    sum: string;
+  }> {
+    const input = this.validateArgs<ExportTransactionsInput>(args);
+
+    try {
+      const requestOptions = {
+        ...(input.since_date && { sinceDate: input.since_date }),
+      };
+
+      let response: YnabTransactionsResponse;
+      if (input.account_id) {
+        response = await this.client.getAccountTransactions(
+          input.budget_id,
+          input.account_id,
+          requestOptions,
+        );
+      } else {
+        response = await this.client.getTransactions(
+          input.budget_id,
+          requestOptions,
+        );
+      }
+
+      const transactions = response.transactions;
+
+      // Sort by date ascending
+      transactions.sort((a, b) => a.date.localeCompare(b.date));
+
+      // Build CSV rows
+      const rows: string[] = [CSV_HEADERS.join(',')];
+      let sum = 0;
+
+      for (const t of transactions) {
+        const amount = t.amount / 1000;
+        sum += amount;
+
+        rows.push([
+          t.date,
+          amount.toFixed(2),
+          csvEscape(t.payee_name),
+          csvEscape(t.category_name),
+          t.cleared,
+          String(t.approved),
+          t.id,
+          csvEscape(t.memo),
+          t.flag_color || '',
+          t.transfer_account_id || '',
+          t.import_id || '',
+        ].join(','));
+      }
+
+      const csv = rows.join('\n');
+
+      // If output_path provided, write to file and return summary
+      if (input.output_path) {
+        writeFileSync(input.output_path, csv, 'utf-8');
+
+        const dates = transactions.map(t => t.date);
+        return {
+          path: input.output_path,
+          count: transactions.length,
+          date_range: {
+            from: dates[0] || '',
+            to: dates[dates.length - 1] || '',
+          },
+          sum: sum.toFixed(2),
+        };
+      }
+
+      // Otherwise return the CSV string directly
+      return csv;
+
+    } catch (error) {
+      this.handleError(error, 'export transactions');
+    }
+  }
+}

--- a/src/tools/transactions/exportTransactions.ts
+++ b/src/tools/transactions/exportTransactions.ts
@@ -5,8 +5,9 @@ import type { YnabTransactionsResponse } from '../../types/index.js';
 
 const ExportTransactionsInputSchema = z.object({
   budget_id: z.string().describe('The ID of the budget to export transactions from'),
-  account_id: z.string().optional().describe('Filter to a specific account'),
+  account_id: z.string().describe('The account ID to export transactions for'),
   since_date: z.string().optional().describe('Only return transactions on or after this date (YYYY-MM-DD)'),
+  all_accounts: z.boolean().optional().default(false).describe('If true, ignore account_id and export all transactions across all accounts'),
   output_path: z.string().optional().describe('If provided, write CSV to this file path and return a summary instead of the full CSV. Useful for large accounts.'),
 });
 
@@ -42,7 +43,7 @@ const CSV_HEADERS = [
  */
 export class ExportTransactionsTool extends YnabTool {
   name = 'ynab_export_transactions_csv';
-  description = 'Export all transactions for a budget or account as a compact CSV string. Returns flat rows with amounts in dollars — much smaller than the JSON format. Optionally writes to a file. No row limit.';
+  description = 'Export all transactions for a single account as a compact CSV string. Requires account_id. Returns flat rows with amounts in dollars — much smaller than the JSON format. Optionally writes to a file. No row limit. Set all_accounts=true to export across all accounts.';
   inputSchema = ExportTransactionsInputSchema;
 
   async execute(args: unknown): Promise<string | {
@@ -59,15 +60,15 @@ export class ExportTransactionsTool extends YnabTool {
       };
 
       let response: YnabTransactionsResponse;
-      if (input.account_id) {
-        response = await this.client.getAccountTransactions(
+      if (input.all_accounts) {
+        response = await this.client.getTransactions(
           input.budget_id,
-          input.account_id,
           requestOptions,
         );
       } else {
-        response = await this.client.getTransactions(
+        response = await this.client.getAccountTransactions(
           input.budget_id,
+          input.account_id,
           requestOptions,
         );
       }


### PR DESCRIPTION
## Summary
- Adds `ynab_export_transactions_csv` tool that exports all transactions as compact CSV
- No row limit — returns the full account history in one call
- Amounts in dollars (not milliunits) for direct comparison with bank CSVs
- Optional `output_path` parameter to write CSV to disk instead of returning the string
- CSV columns: date, amount, payee_name, category, cleared, approved, id, memo, flag_color, transfer_account_id, import_id

## Motivation
Pulling all transactions with `ynab_get_transactions` requires multiple paginated calls (1000 limit), produces ~1MB JSON per batch, and needs post-processing to extract flat fields from nested objects. The CSV format is ~10x smaller and ready for reconciliation workflows.

## Test plan
- [x] Build passes (`npm run build`)
- [x] Tested against live YNAB API — exported 285 transactions for CIBC VISA account in one call
- [x] Verified CSV output: correct headers, amounts in dollars, FX memos preserved
- [x] Verified `output_path` mode returns summary object with count, date range, and sum