### PR TITLE
fix: Exclude on-budget transfers from uncategorized counts

### DIFF
--- a/src/tools/accounts/getAccountSummary.ts
+++ b/src/tools/accounts/getAccountSummary.ts
@@ -33,6 +33,7 @@ export class GetAccountSummaryTool extends YnabTool {
 
       const uncategorizedByAccount = new Map<string, number>();
       for (const tx of uncategorizedResponse.transactions) {
+        if (tx.transfer_account_id) continue; // on-budget transfers intentionally have no category
         uncategorizedByAccount.set(tx.account_id, (uncategorizedByAccount.get(tx.account_id) ?? 0) + 1);
       }
 

--- a/tests/tools/accounts/getAccountSummary.test.ts
+++ b/tests/tools/accounts/getAccountSummary.test.ts
@@ -215,6 +215,36 @@ describe('GetAccountSummaryTool', () => {
       expect(client.getTransactions).toHaveBeenNthCalledWith(2, 'test-budget', { type: 'uncategorized' });
     });
 
+    it('excludes on-budget transfers from uncategorized counts', async () => {
+      const acct = createMockAccount({ id: 'acct-1', name: 'Checking' });
+
+      client.getAccounts.mockResolvedValue({
+        accounts: [acct],
+        server_knowledge: 1,
+      });
+
+      // No unapproved
+      client.getTransactions.mockResolvedValueOnce({
+        transactions: [],
+        server_knowledge: 1,
+      });
+
+      // Uncategorized: 3 total, but 2 are transfers (should be excluded)
+      client.getTransactions.mockResolvedValueOnce({
+        transactions: [
+          createMockTransaction({ account_id: 'acct-1', category_id: null, transfer_account_id: null }),
+          createMockTransaction({ account_id: 'acct-1', category_id: null, transfer_account_id: 'acct-2' }),
+          createMockTransaction({ account_id: 'acct-1', category_id: null, transfer_account_id: 'acct-3' }),
+        ],
+        server_knowledge: 1,
+      });
+
+      const result = await tool.execute({ budget_id: 'test-budget' });
+
+      expect(result.accounts[0].uncategorized_count).toBe(1);
+      expect(result.totals.total_uncategorized).toBe(1);
+    });
+
     it('handles API errors gracefully', async () => {
       client.getAccounts.mockRejectedValue(new Error('API error'));
 


### PR DESCRIPTION
## Summary
- On-budget transfers intentionally have no category in YNAB (GUI shows "Category not needed")
- The API reports these as uncategorized, inflating the `uncategorized_count` in `ynab_get_account_summary`
- One-line fix: skip transactions with `transfer_account_id` when counting uncategorized

## Test plan
- [x] New test: verifies 2 transfers + 1 real uncategorized = count of 1 (not 3)
- [x] All 310 existing tests pass
- [x] Lint and build clean