### PR TITLE
feat: Add needs_attention filter to ynab_get_transactions

### DIFF
--- a/src/tools/transactions/getTransactions.ts
+++ b/src/tools/transactions/getTransactions.ts
@@ -19,7 +19,7 @@ const GetTransactionsInputSchema = z.object({
   budget_id: z.string().describe('The ID of the budget to get transactions for'),
   account_id: z.string().optional().describe('Filter transactions to a specific account'),
   since_date: z.string().optional().describe('Only return transactions on or after this date (ISO format: YYYY-MM-DD)'),
-  type: z.enum(['uncategorized', 'unapproved']).optional().describe('Filter transactions by type'),
+  type: z.enum(['uncategorized', 'unapproved', 'needs_attention']).optional().describe('Filter transactions by type. "needs_attention" combines unapproved + uncategorized (excluding transfers) in one query.'),
   last_knowledge_of_server: z.number().optional().describe('Server knowledge for delta sync - only return data modified since this value'),
   category_id: z.string().optional().describe('Filter transactions to a specific category'),
   payee_id: z.string().optional().describe('Filter transactions to a specific payee'),
@@ -123,24 +123,61 @@ export class GetTransactionsTool extends YnabTool {
     try {
       let transactionsResponse: YnabTransactionsResponse;
 
-      // Get transactions - either from specific account or all accounts
-      const requestOptions = {
-        ...(input.since_date && { sinceDate: input.since_date }),
-        ...(input.type && { type: input.type }),
-        ...(input.last_knowledge_of_server !== undefined && { lastKnowledgeOfServer: input.last_knowledge_of_server }),
-      };
+      if (input.type === 'needs_attention') {
+        // Fetch both unapproved and uncategorized, merge and deduplicate
+        const baseOptions = {
+          ...(input.since_date && { sinceDate: input.since_date }),
+          ...(input.last_knowledge_of_server !== undefined && { lastKnowledgeOfServer: input.last_knowledge_of_server }),
+        };
 
-      if (input.account_id) {
-        transactionsResponse = await this.client.getAccountTransactions(
-          input.budget_id,
-          input.account_id,
-          requestOptions
+        const fetchFn = input.account_id
+          ? (opts: any) => this.client.getAccountTransactions(input.budget_id, input.account_id!, opts)
+          : (opts: any) => this.client.getTransactions(input.budget_id, opts);
+
+        const [unapprovedResponse, uncategorizedResponse] = await Promise.all([
+          fetchFn({ ...baseOptions, type: 'unapproved' }),
+          fetchFn({ ...baseOptions, type: 'uncategorized' }),
+        ]);
+
+        // Filter uncategorized to exclude transfers (they intentionally have no category)
+        const realUncategorized = uncategorizedResponse.transactions.filter(
+          (tx: any) => !tx.transfer_account_id
         );
+
+        // Merge and deduplicate by ID
+        const seen = new Set<string>();
+        const merged = [];
+        for (const tx of [...unapprovedResponse.transactions, ...realUncategorized]) {
+          if (!seen.has(tx.id)) {
+            seen.add(tx.id);
+            merged.push(tx);
+          }
+        }
+
+        transactionsResponse = {
+          transactions: merged,
+          server_knowledge: Math.max(unapprovedResponse.server_knowledge, uncategorizedResponse.server_knowledge),
+        };
       } else {
-        transactionsResponse = await this.client.getTransactions(
-          input.budget_id,
-          requestOptions
-        );
+        // Standard single-query path
+        const requestOptions = {
+          ...(input.since_date && { sinceDate: input.since_date }),
+          ...(input.type && { type: input.type }),
+          ...(input.last_knowledge_of_server !== undefined && { lastKnowledgeOfServer: input.last_knowledge_of_server }),
+        };
+
+        if (input.account_id) {
+          transactionsResponse = await this.client.getAccountTransactions(
+            input.budget_id,
+            input.account_id,
+            requestOptions
+          );
+        } else {
+          transactionsResponse = await this.client.getTransactions(
+            input.budget_id,
+            requestOptions
+          );
+        }
       }
 
       // Apply additional client-side filtering

--- a/tests/tools/transactions/getTransactions.test.ts
+++ b/tests/tools/transactions/getTransactions.test.ts
@@ -423,4 +423,124 @@ describe('GetTransactionsTool', () => {
       })).rejects.toThrow();
     });
   });
+
+  describe('needs_attention filter', () => {
+    const accountId = 'acct-1';
+
+    it('returns unapproved transactions', async () => {
+      client.getTransactions
+        .mockResolvedValueOnce({
+          transactions: [
+            createMockTransaction({ id: 'unapproved-1', account_id: accountId, approved: false, category_id: 'cat-1' }),
+          ],
+          server_knowledge: 1,
+        })
+        .mockResolvedValueOnce({
+          transactions: [],
+          server_knowledge: 1,
+        });
+
+      const result = await tool.execute({ budget_id: 'test-budget', type: 'needs_attention' });
+
+      expect(result.transactions).toHaveLength(1);
+      expect(result.transactions[0].id).toBe('unapproved-1');
+    });
+
+    it('returns uncategorized non-transfer transactions', async () => {
+      client.getTransactions
+        .mockResolvedValueOnce({
+          transactions: [],
+          server_knowledge: 1,
+        })
+        .mockResolvedValueOnce({
+          transactions: [
+            createMockTransaction({ id: 'uncat-1', account_id: accountId, category_id: null, transfer_account_id: null }),
+          ],
+          server_knowledge: 1,
+        });
+
+      const result = await tool.execute({ budget_id: 'test-budget', type: 'needs_attention' });
+
+      expect(result.transactions).toHaveLength(1);
+      expect(result.transactions[0].id).toBe('uncat-1');
+    });
+
+    it('excludes uncategorized transfers', async () => {
+      client.getTransactions
+        .mockResolvedValueOnce({
+          transactions: [],
+          server_knowledge: 1,
+        })
+        .mockResolvedValueOnce({
+          transactions: [
+            createMockTransaction({ id: 'transfer-1', account_id: accountId, category_id: null, transfer_account_id: 'acct-2' }),
+            createMockTransaction({ id: 'real-uncat', account_id: accountId, category_id: null, transfer_account_id: null }),
+          ],
+          server_knowledge: 1,
+        });
+
+      const result = await tool.execute({ budget_id: 'test-budget', type: 'needs_attention' });
+
+      expect(result.transactions).toHaveLength(1);
+      expect(result.transactions[0].id).toBe('real-uncat');
+    });
+
+    it('deduplicates transactions that are both unapproved and uncategorized', async () => {
+      const bothTx = createMockTransaction({ id: 'both-1', account_id: accountId, approved: false, category_id: null, transfer_account_id: null });
+
+      client.getTransactions
+        .mockResolvedValueOnce({
+          transactions: [bothTx],
+          server_knowledge: 1,
+        })
+        .mockResolvedValueOnce({
+          transactions: [bothTx],
+          server_knowledge: 1,
+        });
+
+      const result = await tool.execute({ budget_id: 'test-budget', type: 'needs_attention' });
+
+      expect(result.transactions).toHaveLength(1);
+      expect(result.transactions[0].id).toBe('both-1');
+    });
+
+    it('works with account_id filter', async () => {
+      client.getAccountTransactions
+        .mockResolvedValueOnce({
+          transactions: [
+            createMockTransaction({ id: 'unapproved-1', account_id: accountId, approved: false }),
+          ],
+          server_knowledge: 1,
+        })
+        .mockResolvedValueOnce({
+          transactions: [],
+          server_knowledge: 1,
+        });
+
+      const result = await tool.execute({ budget_id: 'test-budget', type: 'needs_attention', account_id: accountId });
+
+      expect(client.getAccountTransactions).toHaveBeenCalledTimes(2);
+      expect(result.transactions).toHaveLength(1);
+    });
+
+    it('works with compact mode', async () => {
+      client.getTransactions
+        .mockResolvedValueOnce({
+          transactions: [
+            createMockTransaction({ id: 'tx-1', approved: false, flag_color: 'red', import_id: 'imp-1' }),
+          ],
+          server_knowledge: 1,
+        })
+        .mockResolvedValueOnce({
+          transactions: [],
+          server_knowledge: 1,
+        });
+
+      const result = await tool.execute({ budget_id: 'test-budget', type: 'needs_attention', compact: true });
+      const tx = result.transactions[0] as Record<string, unknown>;
+
+      expect(tx).not.toHaveProperty('flag');
+      expect(tx).not.toHaveProperty('import_info');
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- New `type: 'needs_attention'` option that returns transactions genuinely needing human action
- Combines unapproved + uncategorized (excluding transfers) in one query
- Makes 2 parallel API calls internally, merges and deduplicates results
- Works with all existing params (account_id, compact, fields, etc.)

## Test plan
- [x] 6 new tests for needs_attention (unapproved, uncategorized, transfer exclusion, dedup, account filter, compact)
- [x] All 316 existing tests pass
- [x] Lint and build clean