### PR TITLE
fix: Send 'date' (not 'date_first') to YNAB scheduled transactions API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ynab-mcp-server",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Comprehensive Model Context Protocol server providing intelligent access to YNAB (You Need A Budget) data with AI-powered budget recommendations, spending analysis, and complete transaction management",
   "type": "module",
   "main": "dist/index.js",

--- a/src/tools/scheduled/createScheduledTransaction.ts
+++ b/src/tools/scheduled/createScheduledTransaction.ts
@@ -141,9 +141,10 @@ export class CreateScheduledTransactionTool extends YnabTool {
       }
 
       // Prepare scheduled transaction data
+      // Note: YNAB API expects `date` (not `date_first`) in request body
       const scheduledTransactionData: SaveScheduledTransaction = {
         account_id: input.account_id,
-        date_first: input.date_first,
+        date: input.date_first,
         amount: input.amount,
         frequency: input.frequency,
         memo: input.memo || null,

--- a/src/tools/scheduled/updateScheduledTransaction.ts
+++ b/src/tools/scheduled/updateScheduledTransaction.ts
@@ -141,7 +141,8 @@ export class UpdateScheduledTransactionTool extends YnabTool {
       }
 
       if (input.date_first !== undefined) {
-        updateData.date_first = input.date_first;
+        // Note: YNAB API expects `date` (not `date_first`) in request body
+        updateData.date = input.date_first;
       }
 
       if (input.frequency !== undefined) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -328,8 +328,10 @@ export interface UpdateTransactionWithId extends UpdateTransaction {
 export interface SaveScheduledTransaction {
   /** Account ID (required) */
   account_id: string;
-  /** First date in ISO format YYYY-MM-DD (required, max 5 years in future) */
-  date_first: string;
+  /** First date in ISO format YYYY-MM-DD (required, max 5 years in future).
+   *  NOTE: YNAB's POST/PATCH API expects this field to be named `date`, not `date_first`
+   *  (even though responses return `date_first`/`date_next`). */
+  date: string;
   /** Amount in milliunits */
   amount?: number;
   /** Payee ID */

--- a/tests/tools/scheduled/scheduledTransactions.test.ts
+++ b/tests/tools/scheduled/scheduledTransactions.test.ts
@@ -126,6 +126,27 @@ describe('CreateScheduledTransactionTool', () => {
     expect(result.scheduled_transaction.id).toBe('st-new');
   });
 
+  it('sends "date" (not "date_first") to the YNAB API', async () => {
+    // YNAB POST /scheduled_transactions expects the field name `date`, not `date_first`.
+    // Responses return `date_first`/`date_next`, but the request body must use `date`.
+    const mockStx = createMockScheduledTransaction({ id: 'st-new', frequency: 'monthly' });
+    client.createScheduledTransaction.mockResolvedValue({
+      scheduled_transaction: mockStx,
+    });
+
+    await tool.execute({
+      budget_id: 'test-budget',
+      account_id: 'test-account',
+      date_first: '2024-02-01',
+      frequency: 'monthly',
+      amount: -50000,
+    });
+
+    const [, payload] = client.createScheduledTransaction.mock.calls[0];
+    expect(payload).toHaveProperty('date', '2024-02-01');
+    expect(payload).not.toHaveProperty('date_first');
+  });
+
   it('handles API errors gracefully', async () => {
     client.createScheduledTransaction.mockRejectedValue(new Error('API error'));
     await expect(tool.execute({
@@ -171,6 +192,24 @@ describe('UpdateScheduledTransactionTool', () => {
     expect(client.updateScheduledTransaction).toHaveBeenCalled();
     // The tool wraps amount in an object with milliunits and formatted
     expect(result.scheduled_transaction.amount.milliunits).toBe(-75000);
+  });
+
+  it('sends "date" (not "date_first") to the YNAB API when updating date', async () => {
+    // Same as create: PATCH body must use `date`, not `date_first`.
+    const mockStx = createMockScheduledTransaction({ id: 'st-1' });
+    client.updateScheduledTransaction.mockResolvedValue({
+      scheduled_transaction: mockStx,
+    });
+
+    await tool.execute({
+      budget_id: 'test-budget',
+      scheduled_transaction_id: 'st-1',
+      date_first: '2024-03-15',
+    });
+
+    const [, , payload] = client.updateScheduledTransaction.mock.calls[0];
+    expect(payload).toHaveProperty('date', '2024-03-15');
+    expect(payload).not.toHaveProperty('date_first');
   });
 
   it('handles API errors gracefully', async () => {


### PR DESCRIPTION
## Summary

- YNAB's POST/PATCH `/scheduled_transactions` endpoint expects the field name `date` in the request body, but returns `date_first`/`date_next` in responses. The tool was sending `date_first` in the request, causing every create/update to fail with `{"error":{"id":"400","name":"bad_request","detail":"date is required"}}`.
- Fix: rename the outgoing API payload field to `date`. Tool's input parameter remains `date_first` — no breaking change for callers.
- Bumps to v1.2.1 (patch — bug fix).

## Root cause

`SaveScheduledTransaction.date_first` in `src/types/index.ts` was named to match the response field. But YNAB's API is asymmetric: request body uses `date`, response uses `date_first`+`date_next`. Verified against live API.

## Test plan

- [x] Added 2 new tests that assert the payload sent to the client has `date` (not `date_first`) for both create and update
- [x] All 331 existing tests still pass (2 skipped, unrelated)
- [x] `npm run build` succeeds (clean tsc)
- [x] Verified fix end-to-end against live YNAB API via curl — scheduled transaction created successfully