### PR TITLE
fix(update-splits): delete+recreate split txns for YNAB API limitation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ynab-mcp-server",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Comprehensive Model Context Protocol server providing intelligent access to YNAB (You Need A Budget) data with AI-powered budget recommendations, spending analysis, and complete transaction management",
   "type": "module",
   "main": "dist/index.js",

--- a/src/tools/transactions/updateTransactionSplits.ts
+++ b/src/tools/transactions/updateTransactionSplits.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { YnabTool } from '../base.js';
-import type { YnabTransactionsResponse, YnabPayeesResponse, UpdateTransactionWithId, UpdateSubTransaction } from '../../types/index.js';
+import type { YnabTransactionResponse, YnabTransactionsResponse, YnabPayeesResponse, UpdateTransaction, UpdateSubTransaction, ClearedStatus, FlagColor, SaveTransaction } from '../../types/index.js';
 
 /**
  * Schema for updating or adding a subtransaction
@@ -198,10 +198,12 @@ export class UpdateTransactionSplitsTool extends YnabTool {
         }
       }
 
-      // Determine operation type and build update data
-      const updateData: UpdateTransactionWithId = {
-        id: input.transaction_id,
-      };
+      // Determine operation type and build update data.
+      // NOTE: We must use the single-transaction PATCH endpoint
+      // (PATCH /budgets/{id}/transactions/{txn_id}) rather than the bulk
+      // endpoint. YNAB's bulk PATCH does NOT accept a `subtransactions` field
+      // and silently drops it, so subtransaction mutations never persist.
+      const updateData: UpdateTransaction = {};
 
       if (input.convert_to_regular) {
         // Convert split transaction to regular transaction
@@ -296,7 +298,6 @@ export class UpdateTransactionSplitsTool extends YnabTool {
             memo: sub.memo !== undefined ? sub.memo : null,
           };
 
-          // Include ID if updating existing subtransaction
           if (sub.subtransaction_id) {
             processedSub.id = sub.subtransaction_id;
             subtransactionsUpdated++;
@@ -312,8 +313,6 @@ export class UpdateTransactionSplitsTool extends YnabTool {
         // Handle removal of subtransactions
         if (input.remove_subtransaction_ids && input.remove_subtransaction_ids.length > 0) {
           subtransactionsRemoved = input.remove_subtransaction_ids.length;
-          // Note: YNAB API handles removal by omitting subtransactions from the array
-          // The API will remove any existing subtransactions not included in the new array
         }
 
       } else {
@@ -331,17 +330,72 @@ export class UpdateTransactionSplitsTool extends YnabTool {
       if (input.approved !== undefined) updateData.approved = input.approved;
       if (input.flag_color !== undefined) updateData.flag_color = input.flag_color;
 
-      // Execute the update
-      const response: YnabTransactionsResponse = await this.client.updateTransactions(
-        input.budget_id,
-        [updateData]
-      );
+      // Choose the right strategy based on whether we're modifying an existing
+      // split's subtransactions. YNAB's PATCH endpoint silently ignores the
+      // subtransactions array on existing split transactions, so the only way
+      // to change subtxn fields is to delete the old transaction and recreate
+      // it with the new subtransactions.
+      let transaction;
+      let serverKnowledge: number;
 
-      if (!response.transactions || response.transactions.length === 0) {
-        throw new Error('No transaction returned from YNAB API after update');
+      if (isCurrentlySplit && updateData.subtransactions && updateData.subtransactions.length > 0) {
+        // DELETE + RECREATE: the only way to modify subtxn categories/memos
+        // on an existing split via the public YNAB API.
+        const newTxnData: SaveTransaction = {
+          account_id: currentTransaction.account_id,
+          date: input.date ?? currentTransaction.date,
+          amount: updateData.amount ?? currentTransaction.amount,
+          payee_id: updateData.payee_id ?? currentTransaction.payee_id,
+          payee_name: input.payee_name ?? currentTransaction.payee_name,
+          memo: input.memo !== undefined ? input.memo : currentTransaction.memo,
+          cleared: (input.cleared ?? currentTransaction.cleared) as ClearedStatus | null,
+          approved: input.approved ?? currentTransaction.approved,
+          flag_color: (input.flag_color !== undefined ? input.flag_color : currentTransaction.flag_color) as FlagColor,
+          // Generate a new import_id to avoid duplicate rejection.
+          // The original import_id is still in YNAB's dedup history even
+          // after deletion, so reusing it would cause the create to be
+          // silently treated as a duplicate.
+          import_id: `split_recreate_${Date.now()}`,
+          subtransactions: updateData.subtransactions.map(sub => ({
+            amount: sub.amount,
+            category_id: sub.category_id ?? null,
+            payee_id: sub.payee_id ?? null,
+            memo: sub.memo ?? null,
+          })),
+        };
+
+        // Step 1: Delete old transaction
+        await this.client.delete(`/budgets/${input.budget_id}/transactions/${input.transaction_id}`);
+
+        // Step 2: Create new transaction with updated subtransactions
+        const createResponse: YnabTransactionsResponse = await this.client.createTransactions(
+          input.budget_id,
+          [newTxnData]
+        );
+
+        if (!createResponse.transactions || createResponse.transactions.length === 0) {
+          throw new Error('Failed to recreate transaction after delete');
+        }
+
+        transaction = createResponse.transactions[0]!;
+        serverKnowledge = createResponse.server_knowledge;
+
+      } else {
+        // PATCH: works for converting regular→split, split→regular, and
+        // main-field-only updates on existing splits.
+        const response: YnabTransactionResponse = await this.client.updateTransaction(
+          input.budget_id,
+          input.transaction_id,
+          updateData
+        );
+
+        if (!response.transaction) {
+          throw new Error('No transaction returned from YNAB API after update');
+        }
+
+        transaction = response.transaction;
+        serverKnowledge = response.server_knowledge;
       }
-
-      const transaction = response.transactions[0]!;
       const isSplit = !!(transaction.subtransactions && transaction.subtransactions.length > 0);
 
       const result: any = {
@@ -405,7 +459,7 @@ export class UpdateTransactionSplitsTool extends YnabTool {
       return {
         transaction: result,
         created_payees: createdPayees,
-        server_knowledge: response.server_knowledge,
+        server_knowledge: serverKnowledge,
         operation_summary: {
           operation_type: operationType,
           subtransactions_added: subtransactionsAdded,

--- a/tests/tools/transactions/updateTransactionSplits.test.ts
+++ b/tests/tools/transactions/updateTransactionSplits.test.ts
@@ -1,0 +1,275 @@
+/**
+ * UpdateTransactionSplitsTool Unit Tests
+ *
+ * YNAB API limitation: the PATCH endpoint silently ignores the `subtransactions`
+ * array on existing transactions. Subtransactions are immutable once created.
+ *
+ * Workaround: when modifying subtransactions on an existing split, the tool
+ * deletes the old transaction and recreates it with the new subtransaction
+ * categories/memos/amounts. This is the only reliable way to change subtxn
+ * fields via the public YNAB API.
+ *
+ * Creating a NEW split from a regular transaction still uses PATCH (works fine).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { UpdateTransactionSplitsTool } from '../../../src/tools/transactions/updateTransactionSplits.js';
+import { createMockClient, type MockYNABClient } from '../../helpers/mockClient.js';
+import { createMockTransaction, createMockSplitTransaction } from '../../helpers/fixtures.js';
+
+describe('UpdateTransactionSplitsTool', () => {
+  let client: MockYNABClient;
+  let tool: UpdateTransactionSplitsTool;
+
+  beforeEach(() => {
+    client = createMockClient();
+    tool = new UpdateTransactionSplitsTool(client as any);
+  });
+
+  describe('metadata', () => {
+    it('has correct name', () => {
+      expect(tool.name).toBe('ynab_update_transaction_splits');
+    });
+  });
+
+  describe('modifying existing split: delete + recreate', () => {
+    it('deletes old transaction and creates new one when updating subtxns on existing split', async () => {
+      const splitTxn = createMockSplitTransaction(2, {
+        id: 'split-1',
+        account_id: 'acct-1',
+        date: '2025-01-18',
+        amount: -100000,
+        payee_id: 'payee-1',
+        payee_name: 'Apple',
+        memo: 'Original memo',
+        cleared: 'cleared',
+        approved: true,
+      });
+      client.getTransactions.mockResolvedValue({
+        transactions: [splitTxn],
+        server_knowledge: 1,
+      });
+      client.delete.mockResolvedValue({
+        transaction: { id: 'split-1', deleted: true },
+        server_knowledge: 2,
+      });
+      const recreatedTxn = createMockSplitTransaction(2, {
+        id: 'new-split-1',
+        account_id: 'acct-1',
+        amount: -100000,
+      });
+      client.createTransactions.mockResolvedValue({
+        transactions: [recreatedTxn],
+        server_knowledge: 3,
+      });
+
+      await tool.execute({
+        budget_id: 'b1',
+        transaction_id: 'split-1',
+        subtransactions: [
+          { subtransaction_id: splitTxn.subtransactions![0]!.id, amount: -60000, category_id: 'cat-movies' },
+          { subtransaction_id: splitTxn.subtransactions![1]!.id, amount: -40000, category_id: 'cat-software' },
+        ],
+      });
+
+      // Should delete the old transaction
+      expect(client.delete).toHaveBeenCalledWith('/budgets/b1/transactions/split-1');
+
+      // Should create a new one with the new subtransaction categories
+      expect(client.createTransactions).toHaveBeenCalledTimes(1);
+      const createCall = client.createTransactions.mock.calls[0]!;
+      const createdTxns = createCall[1] as Array<{
+        account_id: string;
+        date: string;
+        amount: number;
+        subtransactions: Array<{ amount: number; category_id: string }>;
+      }>;
+      expect(createdTxns[0]!.account_id).toBe('acct-1');
+      expect(createdTxns[0]!.date).toBe('2025-01-18');
+      expect(createdTxns[0]!.amount).toBe(-100000);
+      expect(createdTxns[0]!.subtransactions).toHaveLength(2);
+      expect(createdTxns[0]!.subtransactions[0]!.category_id).toBe('cat-movies');
+      expect(createdTxns[0]!.subtransactions[1]!.category_id).toBe('cat-software');
+
+      // Should NOT use updateTransaction or updateTransactions
+      expect(client.updateTransaction).not.toHaveBeenCalled();
+      expect(client.updateTransactions).not.toHaveBeenCalled();
+    });
+
+    it('preserves original transaction properties (date, payee, memo, cleared, approved, flag) on recreate', async () => {
+      const splitTxn = createMockSplitTransaction(2, {
+        id: 'split-props',
+        account_id: 'acct-1',
+        date: '2024-12-22',
+        amount: -100000,
+        payee_id: 'payee-apple',
+        payee_name: 'Apple',
+        memo: 'Multi-item purchase',
+        cleared: 'reconciled',
+        approved: true,
+        flag_color: 'blue',
+        import_id: 'YNAB:-100000:2024-12-22:1',
+      });
+      client.getTransactions.mockResolvedValue({
+        transactions: [splitTxn],
+        server_knowledge: 1,
+      });
+      client.delete.mockResolvedValue({ transaction: { id: 'split-props', deleted: true }, server_knowledge: 2 });
+      client.createTransactions.mockResolvedValue({
+        transactions: [createMockSplitTransaction(2, { id: 'new-id' })],
+        server_knowledge: 3,
+      });
+
+      await tool.execute({
+        budget_id: 'b1',
+        transaction_id: 'split-props',
+        subtransactions: [
+          { amount: -60000, category_id: 'cat-a' },
+          { amount: -40000, category_id: 'cat-b' },
+        ],
+      });
+
+      const createCall = client.createTransactions.mock.calls[0]!;
+      const created = createCall[1][0] as Record<string, unknown>;
+      expect(created.account_id).toBe('acct-1');
+      expect(created.date).toBe('2024-12-22');
+      expect(created.payee_id).toBe('payee-apple');
+      expect(created.memo).toBe('Multi-item purchase');
+      expect(created.cleared).toBe('reconciled');
+      expect(created.approved).toBe(true);
+      expect(created.flag_color).toBe('blue');
+    });
+
+    it('allows overriding main transaction fields during recreate', async () => {
+      const splitTxn = createMockSplitTransaction(2, {
+        id: 'split-override',
+        account_id: 'acct-1',
+        date: '2025-01-18',
+        amount: -100000,
+        memo: 'Old memo',
+      });
+      client.getTransactions.mockResolvedValue({
+        transactions: [splitTxn],
+        server_knowledge: 1,
+      });
+      client.delete.mockResolvedValue({ transaction: { id: 'split-override', deleted: true }, server_knowledge: 2 });
+      client.createTransactions.mockResolvedValue({
+        transactions: [createMockSplitTransaction(2, { id: 'new-id' })],
+        server_knowledge: 3,
+      });
+
+      await tool.execute({
+        budget_id: 'b1',
+        transaction_id: 'split-override',
+        memo: 'New memo',
+        subtransactions: [
+          { amount: -60000, category_id: 'cat-a' },
+          { amount: -40000, category_id: 'cat-b' },
+        ],
+      });
+
+      const created = client.createTransactions.mock.calls[0]![1][0] as Record<string, unknown>;
+      expect(created.memo).toBe('New memo');
+    });
+  });
+
+  describe('creating new split from regular txn: uses PATCH', () => {
+    it('uses updateTransaction when converting regular txn to split (no existing subtxns)', async () => {
+      const regularTxn = createMockTransaction({ id: 'reg-1', amount: -100000, subtransactions: [] });
+      client.getTransactions.mockResolvedValue({
+        transactions: [regularTxn],
+        server_knowledge: 1,
+      });
+      client.updateTransaction.mockResolvedValue({
+        transaction: createMockSplitTransaction(2, { id: 'reg-1', amount: -100000 }),
+      });
+
+      await tool.execute({
+        budget_id: 'b1',
+        transaction_id: 'reg-1',
+        subtransactions: [
+          { amount: -60000, category_id: 'cat-a' },
+          { amount: -40000, category_id: 'cat-b' },
+        ],
+      });
+
+      expect(client.updateTransaction).toHaveBeenCalledTimes(1);
+      expect(client.delete).not.toHaveBeenCalled();
+      expect(client.createTransactions).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('convert to regular: uses PATCH', () => {
+    it('uses updateTransaction when converting split back to regular', async () => {
+      const splitTxn = createMockSplitTransaction(2, { id: 'split-2' });
+      client.getTransactions.mockResolvedValue({
+        transactions: [splitTxn],
+        server_knowledge: 1,
+      });
+      client.updateTransaction.mockResolvedValue({
+        transaction: createMockTransaction({ id: 'split-2', subtransactions: [] }),
+      });
+
+      await tool.execute({
+        budget_id: 'b1',
+        transaction_id: 'split-2',
+        convert_to_regular: true,
+        category_id: 'cat-main',
+      });
+
+      expect(client.updateTransaction).toHaveBeenCalledTimes(1);
+      expect(client.updateTransaction).toHaveBeenCalledWith(
+        'b1',
+        'split-2',
+        expect.objectContaining({
+          category_id: 'cat-main',
+          subtransactions: [],
+        })
+      );
+      expect(client.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('input validation', () => {
+    it('throws if transaction not found', async () => {
+      client.getTransactions.mockResolvedValue({ transactions: [], server_knowledge: 1 });
+      await expect(tool.execute({
+        budget_id: 'b1',
+        transaction_id: 'nope',
+        subtransactions: [{ amount: -1000, category_id: 'c' }],
+      })).rejects.toThrow();
+    });
+
+    it('throws if subtransaction amounts do not sum to total', async () => {
+      const splitTxn = createMockSplitTransaction(2, { id: 'split-4', amount: -100000 });
+      client.getTransactions.mockResolvedValue({
+        transactions: [splitTxn],
+        server_knowledge: 1,
+      });
+
+      await expect(tool.execute({
+        budget_id: 'b1',
+        transaction_id: 'split-4',
+        subtransactions: [
+          { amount: -40000, category_id: 'c1' },
+          { amount: -50000, category_id: 'c2' },
+        ],
+        total_amount: -100000,
+      })).rejects.toThrow(/does not equal target total/);
+    });
+
+    it('throws when convert_to_regular is used without category_id', async () => {
+      const splitTxn = createMockSplitTransaction(2, { id: 'split-5' });
+      client.getTransactions.mockResolvedValue({
+        transactions: [splitTxn],
+        server_knowledge: 1,
+      });
+
+      await expect(tool.execute({
+        budget_id: 'b1',
+        transaction_id: 'split-5',
+        convert_to_regular: true,
+      })).rejects.toThrow(/category_id is required/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- YNAB's public API silently ignores `subtransactions` array when PATCHing existing splits — confirmed via direct cURL testing against both bulk and single-transaction endpoints
- Workaround: when modifying subtxns on existing splits, delete the old transaction and recreate with new subtxn categories/memos
- Fresh import_id generated to avoid YNAB dedup rejection
- Creating NEW splits from regular txns still uses PATCH (unaffected)

## Test plan

- [x] 9 new unit tests covering delete+recreate, PATCH-for-new-splits, convert-to-regular, and input validation
- [x] 340 total tests pass, build clean
- [x] Verified against live YNAB API: 4 movie subtxns successfully moved from iTunes → Movies category (the exact scenario that triggered the bug)