### PR TITLE
fix: enforce import_id 36-char limit at schema level (#9)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ynab-mcp-server",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Comprehensive Model Context Protocol server providing intelligent access to YNAB (You Need A Budget) data with AI-powered budget recommendations, spending analysis, and complete transaction management",
   "type": "module",
   "main": "dist/index.js",

--- a/src/tools/imports/importTransactions.ts
+++ b/src/tools/imports/importTransactions.ts
@@ -13,7 +13,7 @@ const TransactionImportSchema = z.object({
   amount: z.number().describe('Transaction amount in milliunits (1000 = $1.00, negative for outflows)'),
   date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).describe('Transaction date in YYYY-MM-DD format'),
   cleared: z.enum(['cleared', 'uncleared', 'reconciled']).optional().default('uncleared').describe('Cleared status'),
-  import_id: z.string().describe('Unique import ID to prevent duplicates - must be unique across all imports for this budget'),
+  import_id: z.string().max(36, 'Import ID must be 36 characters or less (YNAB API limit)').describe('Unique import ID to prevent duplicates - must be unique across all imports for this budget. Max 36 characters (YNAB API limit).'),
   flag_color: z.enum(['red', 'orange', 'yellow', 'green', 'blue', 'purple']).optional().describe('Flag color (optional)'),
 });
 

--- a/src/tools/transactions/batchUpdateTransactions.ts
+++ b/src/tools/transactions/batchUpdateTransactions.ts
@@ -17,7 +17,7 @@ const BatchTransactionUpdateSchema = z.object({
   cleared: z.enum(['cleared', 'uncleared', 'reconciled']).optional().describe('Update cleared status'),
   approved: z.boolean().optional().describe('Update approval status'),
   flag_color: z.enum(['red', 'orange', 'yellow', 'green', 'blue', 'purple']).nullable().optional().describe('Update flag color. Use null to clear flag'),
-  import_id: z.string().nullable().optional().describe('Update import ID. Use null to clear import ID'),
+  import_id: z.string().max(36, 'Import ID must be 36 characters or less (YNAB API limit)').nullable().optional().describe('Update import ID. Use null to clear import ID. Max 36 characters (YNAB API limit).'),
 });
 
 /**
@@ -180,11 +180,6 @@ export class BatchUpdateTransactionsTool extends YnabTool {
                   }
                 }
               }
-            }
-
-            // Validate import_id format if provided
-            if (transactionUpdate.import_id && transactionUpdate.import_id.length > 36) {
-              throw new Error('Import ID must be 36 characters or less');
             }
 
             // Build update data

--- a/src/tools/transactions/createTransaction.ts
+++ b/src/tools/transactions/createTransaction.ts
@@ -17,7 +17,7 @@ const CreateTransactionInputSchema = z.object({
   cleared: z.enum(['cleared', 'uncleared', 'reconciled']).optional().default('uncleared').describe('Cleared status of the transaction'),
   approved: z.boolean().optional().default(true).describe('Whether the transaction is approved'),
   flag_color: z.enum(['red', 'orange', 'yellow', 'green', 'blue', 'purple']).nullable().optional().describe('Flag color for the transaction'),
-  import_id: z.string().optional().describe('Optional import ID for deduplication. Must be unique within the budget'),
+  import_id: z.string().max(36, 'Import ID must be 36 characters or less (YNAB API limit)').optional().describe('Optional import ID for deduplication. Must be unique within the budget. Max 36 characters (YNAB API limit).'),
 });
 
 type CreateTransactionInput = z.infer<typeof CreateTransactionInputSchema>;
@@ -115,14 +115,6 @@ export class CreateTransactionTool extends YnabTool {
         } catch (payeeError) {
           // If payee creation fails, continue without payee
           console.warn('Failed to create payee, continuing without payee:', payeeError);
-        }
-      }
-
-      // Validate import_id format if provided
-      if (input.import_id) {
-        // YNAB import IDs should be unique strings, often in YNAB:amount:payee:date format
-        if (input.import_id.length > 36) {
-          throw new Error('Import ID must be 36 characters or less');
         }
       }
 

--- a/tests/tools/imports/importTransactions.test.ts
+++ b/tests/tools/imports/importTransactions.test.ts
@@ -72,6 +72,38 @@ describe('ImportTransactionsTool', () => {
         ],
       })).rejects.toThrow('Duplicate import_ids found within the batch');
     });
+
+    it('rejects import_id longer than 36 characters', async () => {
+      await expect(tool.execute({
+        budget_id: 'test-budget',
+        transactions: [{
+          account_id: 'acct-1',
+          amount: -50000,
+          date: '2024-01-15',
+          import_id: 'a'.repeat(37),
+        }],
+      })).rejects.toThrow(/36 characters/);
+    });
+
+    it('accepts import_id of exactly 36 characters', async () => {
+      client.createTransactions.mockResolvedValue({
+        transactions: [createMockTransaction({
+          id: 'tx-1',
+          import_id: 'a'.repeat(36),
+        })],
+        server_knowledge: 1,
+      });
+
+      await expect(tool.execute({
+        budget_id: 'test-budget',
+        transactions: [{
+          account_id: 'acct-1',
+          amount: -50000,
+          date: '2024-01-15',
+          import_id: 'a'.repeat(36),
+        }],
+      })).resolves.toBeDefined();
+    });
   });
 
   describe('execute', () => {


### PR DESCRIPTION
## Summary
- Closes #9
- Move YNAB's 36-char `import_id` limit into the Zod schema for `ynab_create_transaction`, `ynab_import_transactions`, and `ynab_batch_update_transactions` so the constraint is visible to MCP clients and caught before the API call.
- Removes redundant runtime-only checks now covered by the schema.

## Why
Previously `ynab_import_transactions` had no length check at all, and on `ynab_create_transaction`/`ynab_batch_update_transactions` it lived in the `execute` body — invisible to introspecting clients. Over-long IDs reached YNAB and came back as a generic 400, leaving callers to guess.

## Test plan
- [x] Added red/green tests in `tests/tools/imports/importTransactions.test.ts` for the 37-char rejection and 36-char acceptance paths.
- [x] Existing `createTransaction` import_id length test still passes against the schema-level validator.
- [x] `npm test` — 342 passed | 2 skipped.
- [x] `npm run lint` clean.