### PR TITLE
fix(import): auto-approve reconciled imports (#10)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ynab-mcp-server",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "Comprehensive Model Context Protocol server providing intelligent access to YNAB (You Need A Budget) data with AI-powered budget recommendations, spending analysis, and complete transaction management",
   "type": "module",
   "main": "dist/index.js",

--- a/src/tools/imports/importTransactions.ts
+++ b/src/tools/imports/importTransactions.ts
@@ -12,7 +12,8 @@ const TransactionImportSchema = z.object({
   memo: z.string().optional().describe('Transaction memo (optional)'),
   amount: z.number().describe('Transaction amount in milliunits (1000 = $1.00, negative for outflows)'),
   date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).describe('Transaction date in YYYY-MM-DD format'),
-  cleared: z.enum(['cleared', 'uncleared', 'reconciled']).optional().default('uncleared').describe('Cleared status'),
+  cleared: z.enum(['cleared', 'uncleared', 'reconciled']).optional().default('uncleared').describe('Cleared status. Note: "reconciled" requires approved=true; the tool auto-approves reconciled imports.'),
+  approved: z.boolean().optional().describe('Whether the transaction is approved. Defaults to false (YNAB import convention), but automatically set to true when cleared="reconciled" since YNAB silently downgrades unapproved+reconciled to cleared.'),
   import_id: z.string().describe('Unique import ID to prevent duplicates - must be unique across all imports for this budget'),
   flag_color: z.enum(['red', 'orange', 'yellow', 'green', 'blue', 'purple']).optional().describe('Flag color (optional)'),
 });
@@ -40,7 +41,7 @@ type TransactionImport = z.infer<typeof TransactionImportSchema>;
  */
 export class ImportTransactionsTool extends YnabTool {
   name = 'ynab_import_transactions';
-  description = 'Import multiple transactions with automatic deduplication. Each transaction must have a unique import_id. Supports batch import up to 100 transactions. Returns duplicate_import_ids for transactions that were not imported.';
+  description = 'Import multiple transactions with automatic deduplication. Each transaction must have a unique import_id. Supports batch import up to 100 transactions. Returns duplicate_import_ids for transactions that were not imported, and cleared_mismatches listing any transactions whose cleared status YNAB changed (e.g. reconciled downgraded to cleared). Reconciled imports are auto-approved since YNAB silently downgrades cleared=reconciled on unapproved transactions.';
   inputSchema = ImportTransactionsInputSchema;
 
   /**
@@ -83,6 +84,11 @@ export class ImportTransactionsTool extends YnabTool {
       };
     }>;
     duplicate_import_ids: string[];
+    cleared_mismatches: Array<{
+      import_id: string;
+      requested: string;
+      actual: string;
+    }>;
     server_knowledge: number;
     import_summary: {
       total_submitted: number;
@@ -103,6 +109,8 @@ export class ImportTransactionsTool extends YnabTool {
       }
 
       // Prepare transactions for import
+      // YNAB silently downgrades cleared=reconciled unless approved=true, so
+      // reconciled imports are auto-approved when approved is not specified.
       const transactionsToImport = input.transactions.map((tx: TransactionImport) => ({
         account_id: tx.account_id,
         payee_name: tx.payee_name || null,
@@ -111,7 +119,7 @@ export class ImportTransactionsTool extends YnabTool {
         amount: tx.amount,
         date: tx.date,
         cleared: tx.cleared,
-        approved: false, // Imported transactions start as unapproved
+        approved: tx.approved ?? (tx.cleared === 'reconciled'),
         flag_color: tx.flag_color || null,
         import_id: tx.import_id,
       }));
@@ -160,6 +168,24 @@ export class ImportTransactionsTool extends YnabTool {
       const importedIds = processedTransactions.map(tx => tx.import_info.id);
       const duplicateImportIds = importIds.filter(id => !importedIds.includes(id));
 
+      // Detect when YNAB returned a different cleared status than requested
+      // (most commonly "reconciled" requests downgraded to "cleared" or
+      // "uncleared" — see issue #10)
+      const requestedClearedByImportId = new Map(
+        input.transactions.map(tx => [tx.import_id, tx.cleared])
+      );
+      const clearedMismatches: Array<{ import_id: string; requested: string; actual: string }> = [];
+      for (const tx of processedTransactions) {
+        const requested = requestedClearedByImportId.get(tx.import_info.id);
+        if (requested && requested !== tx.cleared) {
+          clearedMismatches.push({
+            import_id: tx.import_info.id,
+            requested,
+            actual: tx.cleared,
+          });
+        }
+      }
+
       // Create import summary
       const importSummary = {
         total_submitted: input.transactions.length,
@@ -170,6 +196,7 @@ export class ImportTransactionsTool extends YnabTool {
       return {
         transactions: processedTransactions,
         duplicate_import_ids: duplicateImportIds,
+        cleared_mismatches: clearedMismatches,
         server_knowledge: importResponse.server_knowledge,
         import_summary: importSummary,
       };

--- a/src/tools/imports/importTransactions.ts
+++ b/src/tools/imports/importTransactions.ts
@@ -14,7 +14,7 @@ const TransactionImportSchema = z.object({
   date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).describe('Transaction date in YYYY-MM-DD format'),
   cleared: z.enum(['cleared', 'uncleared', 'reconciled']).optional().default('uncleared').describe('Cleared status. Note: "reconciled" requires approved=true; the tool auto-approves reconciled imports.'),
   approved: z.boolean().optional().describe('Whether the transaction is approved. Defaults to false (YNAB import convention), but automatically set to true when cleared="reconciled" since YNAB silently downgrades unapproved+reconciled to cleared.'),
-  import_id: z.string().describe('Unique import ID to prevent duplicates - must be unique across all imports for this budget'),
+  import_id: z.string().max(36, 'Import ID must be 36 characters or less (YNAB API limit)').describe('Unique import ID to prevent duplicates - must be unique across all imports for this budget. Max 36 characters (YNAB API limit).'),
   flag_color: z.enum(['red', 'orange', 'yellow', 'green', 'blue', 'purple']).optional().describe('Flag color (optional)'),
 });
 

--- a/tests/tools/imports/importTransactions.test.ts
+++ b/tests/tools/imports/importTransactions.test.ts
@@ -245,6 +245,95 @@ describe('ImportTransactionsTool', () => {
       );
     });
 
+    it('auto-approves reconciled imports (YNAB requires approved+reconciled)', async () => {
+      const mockTx = createMockTransaction({
+        id: 'tx-1',
+        import_id: 'imp-1',
+        cleared: 'reconciled',
+        approved: true,
+      });
+
+      client.createTransactions.mockResolvedValue({
+        transactions: [mockTx],
+        server_knowledge: 100,
+      });
+
+      await tool.execute({
+        budget_id: 'test-budget',
+        transactions: [{
+          account_id: 'acct-1',
+          amount: -50000,
+          date: '2024-01-15',
+          import_id: 'imp-1',
+          cleared: 'reconciled',
+        }],
+      });
+
+      expect(client.createTransactions).toHaveBeenCalledWith(
+        'test-budget',
+        expect.arrayContaining([
+          expect.objectContaining({ cleared: 'reconciled', approved: true }),
+        ])
+      );
+    });
+
+    it('honors explicit approved field when provided', async () => {
+      client.createTransactions.mockResolvedValue({
+        transactions: [createMockTransaction({ id: 'tx-1', import_id: 'imp-1', approved: true })],
+        server_knowledge: 1,
+      });
+
+      await tool.execute({
+        budget_id: 'test-budget',
+        transactions: [{
+          account_id: 'acct-1',
+          amount: -50000,
+          date: '2024-01-15',
+          import_id: 'imp-1',
+          approved: true,
+        }],
+      });
+
+      expect(client.createTransactions).toHaveBeenCalledWith(
+        'test-budget',
+        expect.arrayContaining([
+          expect.objectContaining({ approved: true }),
+        ])
+      );
+    });
+
+    it('surfaces cleared_mismatches when YNAB downgrades reconciled', async () => {
+      client.createTransactions.mockResolvedValue({
+        transactions: [
+          createMockTransaction({
+            id: 'tx-1',
+            import_id: 'imp-1',
+            cleared: 'cleared',
+            approved: true,
+          }),
+        ],
+        server_knowledge: 100,
+      });
+
+      const result = await tool.execute({
+        budget_id: 'test-budget',
+        transactions: [{
+          account_id: 'acct-1',
+          amount: -50000,
+          date: '2024-01-15',
+          import_id: 'imp-1',
+          cleared: 'reconciled',
+        }],
+      });
+
+      expect(result.cleared_mismatches).toHaveLength(1);
+      expect(result.cleared_mismatches[0]).toMatchObject({
+        import_id: 'imp-1',
+        requested: 'reconciled',
+        actual: 'cleared',
+      });
+    });
+
     it('handles API errors gracefully', async () => {
       client.createTransactions.mockRejectedValue(new Error('API error'));
 

--- a/tests/tools/imports/importTransactions.test.ts
+++ b/tests/tools/imports/importTransactions.test.ts
@@ -334,6 +334,37 @@ describe('ImportTransactionsTool', () => {
       );
     });
 
+    it('lets explicit approved=false override the reconciled auto-approve', async () => {
+      client.createTransactions.mockResolvedValue({
+        transactions: [createMockTransaction({
+          id: 'tx-1',
+          import_id: 'imp-1',
+          cleared: 'reconciled',
+          approved: false,
+        })],
+        server_knowledge: 1,
+      });
+
+      await tool.execute({
+        budget_id: 'test-budget',
+        transactions: [{
+          account_id: 'acct-1',
+          amount: -50000,
+          date: '2024-01-15',
+          import_id: 'imp-1',
+          cleared: 'reconciled',
+          approved: false,
+        }],
+      });
+
+      expect(client.createTransactions).toHaveBeenCalledWith(
+        'test-budget',
+        expect.arrayContaining([
+          expect.objectContaining({ cleared: 'reconciled', approved: false }),
+        ])
+      );
+    });
+
     it('surfaces cleared_mismatches when YNAB downgrades reconciled', async () => {
       client.createTransactions.mockResolvedValue({
         transactions: [


### PR DESCRIPTION
## Summary
- Closes #10
- YNAB silently downgrades `cleared=reconciled` to `cleared` when `approved=false`. `ynab_import_transactions` was hardcoding `approved: false` for every import, which is why reconciled backfills came back as `cleared` and appeared "silently dropped."
- Auto-approve reconciled imports (overridable via new optional `approved` field).
- Surface `cleared_mismatches` in the response so any remaining status drift is visible instead of silent.

## Test plan
- [x] Red/green: \`auto-approves reconciled imports\`
- [x] Red/green: \`honors explicit approved field when provided\`
- [x] Red/green: \`surfaces cleared_mismatches when YNAB downgrades reconciled\`
- [x] \`npm test\` — 343 passed | 2 skipped
- [x] \`npm run lint\` clean
- [x] Bumped to v1.3.0 per CLAUDE.md semver policy (new parameter + new return field)