### PR TITLE
fix: reject reserved payee names with clear error (#11)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ynab-mcp-server",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Comprehensive Model Context Protocol server providing intelligent access to YNAB (You Need A Budget) data with AI-powered budget recommendations, spending analysis, and complete transaction management",
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ynab-mcp-server",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Comprehensive Model Context Protocol server providing intelligent access to YNAB (You Need A Budget) data with AI-powered budget recommendations, spending analysis, and complete transaction management",
   "type": "module",
   "main": "dist/index.js",

--- a/src/tools/common/reservedPayees.ts
+++ b/src/tools/common/reservedPayees.ts
@@ -1,0 +1,32 @@
+/**
+ * YNAB reserves a handful of payee names for internal use (reconciliation
+ * and manual balance adjustments). Creating a transaction with one of these
+ * payee names via the API returns a generic "Bad request" error with no
+ * indication that the payee name is the cause — see issue #11.
+ *
+ * This list is matched case-insensitively.
+ */
+const RESERVED_PAYEE_NAMES = [
+  'Reconciliation Balance Adjustment',
+  'Manual Balance Adjustment',
+  'Starting Balance',
+] as const;
+
+/**
+ * Throws a clear, actionable error if the supplied payee name is reserved
+ * by YNAB. Safe to pass undefined/empty (no-op).
+ */
+export function assertPayeeNameAllowed(name: string | undefined | null): void {
+  if (!name) return;
+  const normalized = name.trim().toLowerCase();
+  const match = RESERVED_PAYEE_NAMES.find(r => r.toLowerCase() === normalized);
+  if (match) {
+    throw new Error(
+      `Payee name "${name}" is reserved by YNAB and cannot be set via the API. ` +
+        `Reserved names: ${RESERVED_PAYEE_NAMES.join(', ')}. ` +
+        `Consider a different payee name and noting the original in the memo.`
+    );
+  }
+}
+
+export { RESERVED_PAYEE_NAMES };

--- a/src/tools/imports/importTransactions.ts
+++ b/src/tools/imports/importTransactions.ts
@@ -99,12 +99,14 @@ export class ImportTransactionsTool extends YnabTool {
   }> {
     const input = this.validateArgs<ImportTransactionsInput>(args);
 
-    try {
-      // Reject reserved YNAB payee names early with a clear error (issue #11)
-      for (const tx of input.transactions) {
-        assertPayeeNameAllowed(tx.payee_name);
-      }
+    // Reject reserved YNAB payee names early with a clear error (issue #11).
+    // This must sit outside the try block so the validation error surfaces
+    // directly instead of being wrapped by the catch handler.
+    for (const tx of input.transactions) {
+      assertPayeeNameAllowed(tx.payee_name);
+    }
 
+    try {
       // Validate unique import_ids within the batch
       const importIds = input.transactions.map(tx => tx.import_id);
       const uniqueImportIds = new Set(importIds);

--- a/src/tools/imports/importTransactions.ts
+++ b/src/tools/imports/importTransactions.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { YnabTool } from '../base.js';
+import { assertPayeeNameAllowed } from '../common/reservedPayees.js';
 import type { YnabTransactionsResponse } from '../../types/index.js';
 
 /**
@@ -93,6 +94,11 @@ export class ImportTransactionsTool extends YnabTool {
     const input = this.validateArgs<ImportTransactionsInput>(args);
 
     try {
+      // Reject reserved YNAB payee names early with a clear error (issue #11)
+      for (const tx of input.transactions) {
+        assertPayeeNameAllowed(tx.payee_name);
+      }
+
       // Validate unique import_ids within the batch
       const importIds = input.transactions.map(tx => tx.import_id);
       const uniqueImportIds = new Set(importIds);

--- a/src/tools/transactions/batchUpdateTransactions.ts
+++ b/src/tools/transactions/batchUpdateTransactions.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { YnabTool } from '../base.js';
+import { assertPayeeNameAllowed } from '../common/reservedPayees.js';
 import type { YnabTransactionsResponse, YnabPayeesResponse, YnabTransaction, UpdateTransactionWithId } from '../../types/index.js';
 
 /**
@@ -107,6 +108,9 @@ export class BatchUpdateTransactionsTool extends YnabTool {
     }>;
   }> {
     const input = this.validateArgs<BatchUpdateTransactionsInput>(args);
+    for (const tx of input.transactions) {
+      assertPayeeNameAllowed(tx.payee_name);
+    }
 
     try {
       const allUpdatedTransactions: YnabTransaction[] = [];

--- a/src/tools/transactions/createSplitTransaction.ts
+++ b/src/tools/transactions/createSplitTransaction.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { YnabTool } from '../base.js';
+import { assertPayeeNameAllowed } from '../common/reservedPayees.js';
 import type { YnabTransactionsResponse, YnabPayeesResponse, SaveTransaction } from '../../types/index.js';
 
 /**
@@ -117,6 +118,10 @@ export class CreateSplitTransactionTool extends YnabTool {
     };
   }> {
     const input = this.validateArgs<CreateSplitTransactionInput>(args);
+    assertPayeeNameAllowed(input.payee_name);
+    for (const sub of input.subtransactions) {
+      assertPayeeNameAllowed(sub.payee_name);
+    }
 
     try {
       // Validate that subtransactions sum to total amount

--- a/src/tools/transactions/createTransaction.ts
+++ b/src/tools/transactions/createTransaction.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { YnabTool } from '../base.js';
+import { assertPayeeNameAllowed } from '../common/reservedPayees.js';
 import type { YnabTransactionsResponse, YnabPayeesResponse } from '../../types/index.js';
 
 /**
@@ -80,6 +81,7 @@ export class CreateTransactionTool extends YnabTool {
     server_knowledge: number;
   }> {
     const input = this.validateArgs<CreateTransactionInput>(args);
+    assertPayeeNameAllowed(input.payee_name);
 
     try {
       let payeeId = input.payee_id;

--- a/src/tools/transactions/updateTransaction.ts
+++ b/src/tools/transactions/updateTransaction.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { YnabTool } from '../base.js';
+import { assertPayeeNameAllowed } from '../common/reservedPayees.js';
 import type { YnabTransactionsResponse, YnabPayeesResponse, UpdateTransactionWithId } from '../../types/index.js';
 
 /**
@@ -86,6 +87,7 @@ export class UpdateTransactionTool extends YnabTool {
     changes_made: string[];
   }> {
     const input = this.validateArgs<UpdateTransactionInput>(args);
+    assertPayeeNameAllowed(input.payee_name);
 
     try {
       let payeeId = input.payee_id;

--- a/src/tools/transactions/updateTransactionSplits.ts
+++ b/src/tools/transactions/updateTransactionSplits.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { YnabTool } from '../base.js';
+import { assertPayeeNameAllowed } from '../common/reservedPayees.js';
 import type { YnabTransactionResponse, YnabTransactionsResponse, YnabPayeesResponse, UpdateTransaction, UpdateSubTransaction, ClearedStatus, FlagColor, SaveTransaction } from '../../types/index.js';
 
 /**
@@ -132,6 +133,10 @@ export class UpdateTransactionSplitsTool extends YnabTool {
     };
   }> {
     const input = this.validateArgs<UpdateTransactionSplitsInput>(args);
+    assertPayeeNameAllowed(input.payee_name);
+    for (const sub of input.subtransactions ?? []) {
+      assertPayeeNameAllowed(sub.payee_name);
+    }
 
     try {
       // First, get the current transaction to understand its current state

--- a/src/tools/transfers/unlinkTransfer.ts
+++ b/src/tools/transfers/unlinkTransfer.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { YnabTool } from '../base.js';
+import { assertPayeeNameAllowed } from '../common/reservedPayees.js';
 import type { YnabTransactionResponse, UpdateTransaction } from '../../types/index.js';
 
 /**
@@ -70,6 +71,7 @@ export class UnlinkTransferTool extends YnabTool {
     server_knowledge: number;
   }> {
     const input = this.validateArgs<UnlinkTransferInput>(args);
+    assertPayeeNameAllowed(input.new_payee_name);
 
     try {
       // First, get the current transaction to understand the transfer relationship

--- a/tests/tools/common/reservedPayees.test.ts
+++ b/tests/tools/common/reservedPayees.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { assertPayeeNameAllowed, RESERVED_PAYEE_NAMES } from '../../../src/tools/common/reservedPayees.js';
+
+describe('assertPayeeNameAllowed', () => {
+  it('is a no-op for undefined and empty strings', () => {
+    expect(() => assertPayeeNameAllowed(undefined)).not.toThrow();
+    expect(() => assertPayeeNameAllowed(null)).not.toThrow();
+    expect(() => assertPayeeNameAllowed('')).not.toThrow();
+  });
+
+  it('allows ordinary payee names', () => {
+    expect(() => assertPayeeNameAllowed('Starbucks')).not.toThrow();
+    expect(() => assertPayeeNameAllowed('Adjustment')).not.toThrow();
+    expect(() => assertPayeeNameAllowed('Reconciliation')).not.toThrow();
+  });
+
+  it.each(RESERVED_PAYEE_NAMES)('rejects reserved name "%s"', (name) => {
+    expect(() => assertPayeeNameAllowed(name)).toThrow(/reserved by YNAB/i);
+  });
+
+  it('matches reserved names case-insensitively', () => {
+    expect(() => assertPayeeNameAllowed('reconciliation balance adjustment')).toThrow(/reserved by YNAB/i);
+    expect(() => assertPayeeNameAllowed('STARTING BALANCE')).toThrow(/reserved by YNAB/i);
+  });
+
+  it('trims surrounding whitespace before comparing', () => {
+    expect(() => assertPayeeNameAllowed('  Manual Balance Adjustment  ')).toThrow(/reserved by YNAB/i);
+  });
+
+  it('lists all reserved names in the error message so callers can see alternatives', () => {
+    let caught: unknown;
+    try {
+      assertPayeeNameAllowed('Starting Balance');
+    } catch (e) {
+      caught = e;
+    }
+    const msg = (caught as Error).message;
+    for (const n of RESERVED_PAYEE_NAMES) {
+      expect(msg).toContain(n);
+    }
+  });
+});

--- a/tests/tools/imports/importTransactions.test.ts
+++ b/tests/tools/imports/importTransactions.test.ts
@@ -73,6 +73,22 @@ describe('ImportTransactionsTool', () => {
       })).rejects.toThrow('Duplicate import_ids found within the batch');
     });
 
+    it('rejects reserved payee_name on any imported transaction (issue #11)', async () => {
+      await expect(tool.execute({
+        budget_id: 'test-budget',
+        transactions: [
+          {
+            account_id: 'acct-1',
+            amount: -50000,
+            date: '2024-01-15',
+            import_id: 'imp-1',
+            payee_name: 'Reconciliation Balance Adjustment',
+          },
+        ],
+      })).rejects.toThrow(/reserved by YNAB/i);
+      expect(client.createTransactions).not.toHaveBeenCalled();
+    });
+
     it('rejects import_id longer than 36 characters', async () => {
       await expect(tool.execute({
         budget_id: 'test-budget',

--- a/tests/tools/transactions/batchUpdateTransactions.test.ts
+++ b/tests/tools/transactions/batchUpdateTransactions.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { BatchUpdateTransactionsTool } from '../../../src/tools/transactions/batchUpdateTransactions.js';
+import { createMockClient, type MockYNABClient } from '../../helpers/mockClient.js';
+
+describe('BatchUpdateTransactionsTool', () => {
+  let client: MockYNABClient;
+  let tool: BatchUpdateTransactionsTool;
+
+  beforeEach(() => {
+    client = createMockClient();
+    tool = new BatchUpdateTransactionsTool(client as any);
+  });
+
+  it('rejects reserved payee_name on any transaction before hitting the API (issue #11)', async () => {
+    await expect(tool.execute({
+      budget_id: 'b1',
+      transactions: [
+        { transaction_id: 'tx-1', memo: 'ok' },
+        { transaction_id: 'tx-2', payee_name: 'Manual Balance Adjustment' },
+      ],
+    })).rejects.toThrow(/reserved by YNAB/i);
+    expect(client.updateTransactions).not.toHaveBeenCalled();
+  });
+});

--- a/tests/tools/transactions/createSplitTransaction.test.ts
+++ b/tests/tools/transactions/createSplitTransaction.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { CreateSplitTransactionTool } from '../../../src/tools/transactions/createSplitTransaction.js';
+import { createMockClient, type MockYNABClient } from '../../helpers/mockClient.js';
+
+describe('CreateSplitTransactionTool', () => {
+  let client: MockYNABClient;
+  let tool: CreateSplitTransactionTool;
+
+  beforeEach(() => {
+    client = createMockClient();
+    tool = new CreateSplitTransactionTool(client as any);
+  });
+
+  it('rejects reserved parent payee_name (issue #11)', async () => {
+    await expect(tool.execute({
+      budget_id: 'b1',
+      account_id: 'a1',
+      payee_name: 'Starting Balance',
+      amount: -10000,
+      date: '2024-01-15',
+      subtransactions: [
+        { amount: -5000, category_id: 'c1' },
+        { amount: -5000, category_id: 'c2' },
+      ],
+    })).rejects.toThrow(/reserved by YNAB/i);
+    expect(client.createTransactions).not.toHaveBeenCalled();
+  });
+
+  it('rejects reserved subtransaction payee_name (issue #11)', async () => {
+    await expect(tool.execute({
+      budget_id: 'b1',
+      account_id: 'a1',
+      amount: -10000,
+      date: '2024-01-15',
+      subtransactions: [
+        { amount: -5000, category_id: 'c1' },
+        { amount: -5000, category_id: 'c2', payee_name: 'Reconciliation Balance Adjustment' },
+      ],
+    })).rejects.toThrow(/reserved by YNAB/i);
+    expect(client.createTransactions).not.toHaveBeenCalled();
+  });
+});

--- a/tests/tools/transactions/createTransaction.test.ts
+++ b/tests/tools/transactions/createTransaction.test.ts
@@ -170,6 +170,21 @@ describe('CreateTransactionTool', () => {
       })).rejects.toThrow('Import ID must be 36 characters or less');
     });
 
+    it.each([
+      'Reconciliation Balance Adjustment',
+      'Manual Balance Adjustment',
+      'Starting Balance',
+      'reconciliation balance adjustment', // case-insensitive
+    ])('rejects reserved payee name "%s" with a clear error', async (name) => {
+      await expect(tool.execute({
+        budget_id: 'test-budget',
+        account_id: 'test-account',
+        amount: -10000,
+        date: '2024-01-15',
+        payee_name: name,
+      })).rejects.toThrow(/reserved by YNAB/i);
+    });
+
     it('includes import_id in transaction', async () => {
       const mockTx = createMockTransaction({
         id: 'tx-1',

--- a/tests/tools/transactions/updateTransaction.test.ts
+++ b/tests/tools/transactions/updateTransaction.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { UpdateTransactionTool } from '../../../src/tools/transactions/updateTransaction.js';
+import { createMockClient, type MockYNABClient } from '../../helpers/mockClient.js';
+
+describe('UpdateTransactionTool', () => {
+  let client: MockYNABClient;
+  let tool: UpdateTransactionTool;
+
+  beforeEach(() => {
+    client = createMockClient();
+    tool = new UpdateTransactionTool(client as any);
+  });
+
+  it('rejects reserved payee_name before hitting the API (issue #11)', async () => {
+    await expect(tool.execute({
+      budget_id: 'b1',
+      transaction_id: 'tx-1',
+      payee_name: 'Starting Balance',
+    })).rejects.toThrow(/reserved by YNAB/i);
+    expect(client.updateTransaction).not.toHaveBeenCalled();
+  });
+});

--- a/tests/tools/transactions/updateTransactionSplits.test.ts
+++ b/tests/tools/transactions/updateTransactionSplits.test.ts
@@ -272,4 +272,28 @@ describe('UpdateTransactionSplitsTool', () => {
       })).rejects.toThrow(/category_id is required/);
     });
   });
+
+  describe('reserved payee validation', () => {
+    it('rejects reserved parent payee_name before hitting the API', async () => {
+      await expect(tool.execute({
+        budget_id: 'b1',
+        transaction_id: 'split-1',
+        payee_name: 'Reconciliation Balance Adjustment',
+        subtransactions: [
+          { amount: -10000, category_id: 'cat-1' },
+        ],
+      })).rejects.toThrow(/reserved by YNAB/i);
+      expect(client.updateTransaction).not.toHaveBeenCalled();
+    });
+
+    it('rejects reserved subtransaction payee_name', async () => {
+      await expect(tool.execute({
+        budget_id: 'b1',
+        transaction_id: 'split-1',
+        subtransactions: [
+          { amount: -10000, category_id: 'cat-1', payee_name: 'Manual Balance Adjustment' },
+        ],
+      })).rejects.toThrow(/reserved by YNAB/i);
+    });
+  });
 });

--- a/tests/tools/transfers/unlinkTransfer.test.ts
+++ b/tests/tools/transfers/unlinkTransfer.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { UnlinkTransferTool } from '../../../src/tools/transfers/unlinkTransfer.js';
+import { createMockClient, type MockYNABClient } from '../../helpers/mockClient.js';
+
+describe('UnlinkTransferTool', () => {
+  let client: MockYNABClient;
+  let tool: UnlinkTransferTool;
+
+  beforeEach(() => {
+    client = createMockClient();
+    tool = new UnlinkTransferTool(client as any);
+  });
+
+  it('rejects reserved new_payee_name before hitting the API (issue #11)', async () => {
+    await expect(tool.execute({
+      budget_id: 'b1',
+      transaction_id: 'tx-1',
+      new_payee_name: 'Manual Balance Adjustment',
+    })).rejects.toThrow(/reserved by YNAB/i);
+    expect(client.getTransaction).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #11
- YNAB rejects certain payee names (e.g. \`Reconciliation Balance Adjustment\`, \`Manual Balance Adjustment\`, \`Starting Balance\`) on creates/updates with a generic \`Bad request\` — callers had no way to know the payee name was the cause.
- Centralises the reserved list in \`src/tools/common/reservedPayees.ts\` and validates case-insensitively at the top of every tool that accepts \`payee_name\` (create, import, update, batch-update, create-split, update-splits, unlink-transfer).
- Error names the specific reserved value and suggests recording the original in the memo (same workaround used in the #11 backfill).

## Test plan
- [x] Parametrised red/green tests for create_transaction cover all three reserved names plus a case-insensitive case.
- [x] \`npm test\` — 346 passed | 2 skipped
- [x] \`npm run lint\` clean
- [x] Bumped to v1.2.4 (patch, YNAB would have rejected these anyway).