### PR TITLE
feat: batch monthly budgeting tools (#14)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"014b367b-96f4-4643-bf4c-1112c94a5efa","pid":68792,"acquiredAt":1776644811021}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"014b367b-96f4-4643-bf4c-1112c94a5efa","pid":68792,"acquiredAt":1776644811021}

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,5 @@ pids
 
 # Vitest
 coverage
+# Claude Code local state
+.claude/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ynab-mcp-server",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Comprehensive Model Context Protocol server providing intelligent access to YNAB (You Need A Budget) data with AI-powered budget recommendations, spending analysis, and complete transaction management",
   "type": "module",
   "main": "dist/index.js",

--- a/src/tools/budgeting/assignAverageSpend.ts
+++ b/src/tools/budgeting/assignAverageSpend.ts
@@ -9,6 +9,7 @@ import {
   loadBudgetingContext,
   refreshToBeBudgeted,
   wrapAmount,
+  formatAmount,
   type BudgetingResult,
 } from './shared.js';
 
@@ -62,7 +63,10 @@ export class AssignAverageSpendTool extends YnabTool {
           if (activity >= 0) continue; // ignore refunds/income-into-category
           outflows.push(Math.abs(activity));
         }
-        if (outflows.length === 0) continue;
+        if (outflows.length === 0) {
+          skipped.push({ category_id: cur.id, category_name: cur.name, reason: 'no_history' });
+          continue;
+        }
         maxLookbackObserved = Math.max(maxLookbackObserved, outflows.length);
         const avg = Math.round(outflows.reduce((s, v) => s + v, 0) / outflows.length);
         if (avg === cur.budgeted) continue;
@@ -95,7 +99,7 @@ export class AssignAverageSpendTool extends YnabTool {
         dry_run: input.dry_run,
         categories_touched: result.applied,
         total_moved_milliunits: result.total_moved_milliunits,
-        to_be_budgeted_before: { milliunits: ctx.toBeBudgetedBefore, formatted: this.formatCurrency(ctx.toBeBudgetedBefore) },
+        to_be_budgeted_before: formatAmount(ctx.toBeBudgetedBefore),
         to_be_budgeted_after: wrapAmount(toBeBudgetedAfter),
         skipped,
         details: result.details,

--- a/src/tools/budgeting/assignAverageSpend.ts
+++ b/src/tools/budgeting/assignAverageSpend.ts
@@ -1,0 +1,109 @@
+import { z } from 'zod';
+import { YnabTool } from '../base.js';
+import { filterCategories } from './categoryFilters.js';
+import { applyBudgetChanges, type PlannedChange } from './categoryBudgetApplier.js';
+import { priorMonths } from './monthMath.js';
+import {
+  BaseBudgetingInputSchema,
+  buildFilterOptions,
+  loadBudgetingContext,
+  refreshToBeBudgeted,
+  wrapAmount,
+  type BudgetingResult,
+} from './shared.js';
+
+const AssignAverageSpendInputSchema = BaseBudgetingInputSchema.extend({
+  lookback_months: z.number().int().min(1).max(12).optional().default(3)
+    .describe('How many prior months to include in the rolling average. Defaults to 3.'),
+});
+
+type AssignAverageSpendInput = z.infer<typeof AssignAverageSpendInputSchema>;
+
+interface AverageSpendResult extends BudgetingResult {
+  lookback_used: number;
+}
+
+/** Assigns each category an amount equal to the rolling average of its
+ * absolute outflow activity over the most recent `lookback_months`.
+ * Positive activity (refunds) is ignored so the average reflects real
+ * spending. Months where the category didn't exist or had no spending are
+ * excluded from the denominator. */
+export class AssignAverageSpendTool extends YnabTool {
+  name = 'ynab_assign_average_spend';
+  description = 'For each filtered category, set `budgeted` to the rolling average of absolute outflow activity over the most recent `lookback_months` (default 3). Supports dry_run.';
+  inputSchema = AssignAverageSpendInputSchema;
+
+  async execute(args: unknown): Promise<AverageSpendResult> {
+    const input = this.validateArgs<AssignAverageSpendInput>(args);
+
+    try {
+      const ctx = await loadBudgetingContext(this.client, input);
+      const months = priorMonths(input.month, input.lookback_months);
+
+      const priorByMonth = new Map<string, Map<string, number>>();
+      for (const m of months) {
+        const resp = await this.client.getBudgetMonth(input.budget_id, m);
+        const byId = new Map<string, number>(
+          resp.month.categories.map(c => [c.id, c.activity])
+        );
+        priorByMonth.set(m, byId);
+      }
+
+      const filterOpts = buildFilterOptions(input, ctx.closedCcAccountNames);
+      const { kept, skipped } = filterCategories(ctx.categories, filterOpts);
+
+      let maxLookbackObserved = 0;
+      const changes: PlannedChange[] = [];
+      for (const cur of kept) {
+        const outflows: number[] = [];
+        for (const m of months) {
+          const activity = priorByMonth.get(m)?.get(cur.id);
+          if (activity === undefined) continue;
+          if (activity >= 0) continue; // ignore refunds/income-into-category
+          outflows.push(Math.abs(activity));
+        }
+        if (outflows.length === 0) continue;
+        maxLookbackObserved = Math.max(maxLookbackObserved, outflows.length);
+        const avg = Math.round(outflows.reduce((s, v) => s + v, 0) / outflows.length);
+        if (avg === cur.budgeted) continue;
+        changes.push({
+          category_id: cur.id,
+          category_name: cur.name,
+          previous_budgeted: cur.budgeted,
+          new_budgeted: avg,
+          delta: avg - cur.budgeted,
+        });
+      }
+
+      const result = await applyBudgetChanges(
+        this.client,
+        input.budget_id,
+        input.month,
+        changes,
+        { dry_run: input.dry_run }
+      );
+
+      const toBeBudgetedAfter = await refreshToBeBudgeted(
+        this.client,
+        input.budget_id,
+        input.month,
+        input.dry_run
+      );
+
+      return {
+        phase: 'assign_average_spend',
+        dry_run: input.dry_run,
+        categories_touched: result.applied,
+        total_moved_milliunits: result.total_moved_milliunits,
+        to_be_budgeted_before: { milliunits: ctx.toBeBudgetedBefore, formatted: this.formatCurrency(ctx.toBeBudgetedBefore) },
+        to_be_budgeted_after: wrapAmount(toBeBudgetedAfter),
+        skipped,
+        details: result.details,
+        failed: result.failed,
+        lookback_used: maxLookbackObserved,
+      };
+    } catch (error) {
+      this.handleError(error, 'assign average spend');
+    }
+  }
+}

--- a/src/tools/budgeting/assignSameAsLastMonth.ts
+++ b/src/tools/budgeting/assignSameAsLastMonth.ts
@@ -1,0 +1,82 @@
+import { YnabTool } from '../base.js';
+import { filterCategories } from './categoryFilters.js';
+import { applyBudgetChanges, type PlannedChange } from './categoryBudgetApplier.js';
+import { previousMonth } from './monthMath.js';
+import {
+  BaseBudgetingInputSchema,
+  buildFilterOptions,
+  loadBudgetingContext,
+  refreshToBeBudgeted,
+  wrapAmount,
+  type BaseBudgetingInput,
+  type BudgetingResult,
+} from './shared.js';
+
+/** Mirrors YNAB's "Assign Same as Last Month" by copying the prior month's
+ * `budgeted` amount into every category of the target month. Categories
+ * that didn't exist last month are skipped. */
+export class AssignSameAsLastMonthTool extends YnabTool {
+  name = 'ynab_assign_same_as_last_month';
+  description = 'For each filtered category, set `budgeted` to the same amount as the previous month. Categories that did not exist last month are skipped. Supports dry_run.';
+  inputSchema = BaseBudgetingInputSchema;
+
+  async execute(args: unknown): Promise<BudgetingResult> {
+    const input = this.validateArgs<BaseBudgetingInput>(args);
+
+    try {
+      const ctx = await loadBudgetingContext(this.client, input);
+      const prevMonth = previousMonth(input.month);
+      const prevResponse = await this.client.getBudgetMonth(input.budget_id, prevMonth);
+      const prevById = new Map(prevResponse.month.categories.map(c => [c.id, c]));
+
+      const filterOpts = buildFilterOptions(input, ctx.closedCcAccountNames);
+      const { kept, skipped } = filterCategories(ctx.categories, filterOpts);
+
+      const changes: PlannedChange[] = [];
+      for (const cur of kept) {
+        const prev = prevById.get(cur.id);
+        if (!prev) {
+          // Treat "new this month" as excluded so the caller can see why it wasn't touched.
+          skipped.push({ category_id: cur.id, category_name: cur.name, reason: 'excluded' });
+          continue;
+        }
+        changes.push({
+          category_id: cur.id,
+          category_name: cur.name,
+          previous_budgeted: cur.budgeted,
+          new_budgeted: prev.budgeted,
+          delta: prev.budgeted - cur.budgeted,
+        });
+      }
+
+      const result = await applyBudgetChanges(
+        this.client,
+        input.budget_id,
+        input.month,
+        changes,
+        { dry_run: input.dry_run }
+      );
+
+      const toBeBudgetedAfter = await refreshToBeBudgeted(
+        this.client,
+        input.budget_id,
+        input.month,
+        input.dry_run
+      );
+
+      return {
+        phase: 'assign_same_as_last_month',
+        dry_run: input.dry_run,
+        categories_touched: result.applied,
+        total_moved_milliunits: result.total_moved_milliunits,
+        to_be_budgeted_before: { milliunits: ctx.toBeBudgetedBefore, formatted: this.formatCurrency(ctx.toBeBudgetedBefore) },
+        to_be_budgeted_after: wrapAmount(toBeBudgetedAfter),
+        skipped,
+        details: result.details,
+        failed: result.failed,
+      };
+    } catch (error) {
+      this.handleError(error, 'assign same as last month');
+    }
+  }
+}

--- a/src/tools/budgeting/assignSameAsLastMonth.ts
+++ b/src/tools/budgeting/assignSameAsLastMonth.ts
@@ -8,6 +8,7 @@ import {
   loadBudgetingContext,
   refreshToBeBudgeted,
   wrapAmount,
+  formatAmount,
   type BaseBudgetingInput,
   type BudgetingResult,
 } from './shared.js';
@@ -36,8 +37,7 @@ export class AssignSameAsLastMonthTool extends YnabTool {
       for (const cur of kept) {
         const prev = prevById.get(cur.id);
         if (!prev) {
-          // Treat "new this month" as excluded so the caller can see why it wasn't touched.
-          skipped.push({ category_id: cur.id, category_name: cur.name, reason: 'excluded' });
+          skipped.push({ category_id: cur.id, category_name: cur.name, reason: 'no_prior_month' });
           continue;
         }
         changes.push({
@@ -69,7 +69,7 @@ export class AssignSameAsLastMonthTool extends YnabTool {
         dry_run: input.dry_run,
         categories_touched: result.applied,
         total_moved_milliunits: result.total_moved_milliunits,
-        to_be_budgeted_before: { milliunits: ctx.toBeBudgetedBefore, formatted: this.formatCurrency(ctx.toBeBudgetedBefore) },
+        to_be_budgeted_before: formatAmount(ctx.toBeBudgetedBefore),
         to_be_budgeted_after: wrapAmount(toBeBudgetedAfter),
         skipped,
         details: result.details,

--- a/src/tools/budgeting/autoAssignUnderfunded.ts
+++ b/src/tools/budgeting/autoAssignUnderfunded.ts
@@ -32,50 +32,48 @@ export class AutoAssignUnderfundedTool extends YnabTool {
   }
 
   /** Execute against a caller-supplied context. Lets compositions like
-   * AutoBalanceMonth reuse one context load across phases. */
+   * AutoBalanceMonth reuse one context load across phases. Errors are NOT
+   * caught here — the outer `execute()` or the composing tool owns error
+   * wrapping so we don't double-wrap messages. */
   async executeWithContext(input: BaseBudgetingInput, ctx: BudgetingContext): Promise<BudgetingResult> {
-    try {
-      const filterOpts = buildFilterOptions(input, ctx.closedCcAccountNames);
-      const { kept, skipped } = filterCategories(ctx.categories, filterOpts);
+    const filterOpts = buildFilterOptions(input, ctx.closedCcAccountNames);
+    const { kept, skipped } = filterCategories(ctx.categories, filterOpts);
 
-      const changes: PlannedChange[] = kept
-        .filter(c => c.balance < 0)
-        .map(c => ({
-          category_id: c.id,
-          category_name: c.name,
-          previous_budgeted: c.budgeted,
-          new_budgeted: c.budgeted + Math.abs(c.balance),
-          delta: Math.abs(c.balance),
-        }));
+    const changes: PlannedChange[] = kept
+      .filter(c => c.balance < 0)
+      .map(c => ({
+        category_id: c.id,
+        category_name: c.name,
+        previous_budgeted: c.budgeted,
+        new_budgeted: c.budgeted + Math.abs(c.balance),
+        delta: Math.abs(c.balance),
+      }));
 
-      const result = await applyBudgetChanges(
-        this.client,
-        input.budget_id,
-        input.month,
-        changes,
-        { dry_run: input.dry_run }
-      );
+    const result = await applyBudgetChanges(
+      this.client,
+      input.budget_id,
+      input.month,
+      changes,
+      { dry_run: input.dry_run }
+    );
 
-      const toBeBudgetedAfter = await refreshToBeBudgeted(
-        this.client,
-        input.budget_id,
-        input.month,
-        input.dry_run
-      );
+    const toBeBudgetedAfter = await refreshToBeBudgeted(
+      this.client,
+      input.budget_id,
+      input.month,
+      input.dry_run
+    );
 
-      return {
-        phase: 'assign_underfunded',
-        dry_run: input.dry_run,
-        categories_touched: result.applied,
-        total_moved_milliunits: result.total_moved_milliunits,
-        to_be_budgeted_before: formatAmount(ctx.toBeBudgetedBefore),
-        to_be_budgeted_after: wrapAmount(toBeBudgetedAfter),
-        skipped,
-        details: result.details,
-        failed: result.failed,
-      };
-    } catch (error) {
-      this.handleError(error, 'auto-assign underfunded');
-    }
+    return {
+      phase: 'assign_underfunded',
+      dry_run: input.dry_run,
+      categories_touched: result.applied,
+      total_moved_milliunits: result.total_moved_milliunits,
+      to_be_budgeted_before: formatAmount(ctx.toBeBudgetedBefore),
+      to_be_budgeted_after: wrapAmount(toBeBudgetedAfter),
+      skipped,
+      details: result.details,
+      failed: result.failed,
+    };
   }
 }

--- a/src/tools/budgeting/autoAssignUnderfunded.ts
+++ b/src/tools/budgeting/autoAssignUnderfunded.ts
@@ -1,0 +1,70 @@
+import { YnabTool } from '../base.js';
+import { filterCategories } from './categoryFilters.js';
+import { applyBudgetChanges, type PlannedChange } from './categoryBudgetApplier.js';
+import {
+  BaseBudgetingInputSchema,
+  buildFilterOptions,
+  loadBudgetingContext,
+  refreshToBeBudgeted,
+  wrapAmount,
+  type BaseBudgetingInput,
+  type BudgetingResult,
+} from './shared.js';
+
+/** Mirrors YNAB's "Auto-Assign → Underfunded" button: every category whose
+ * month-balance is negative is funded with exactly enough to bring balance
+ * back to $0. */
+export class AutoAssignUnderfundedTool extends YnabTool {
+  name = 'ynab_auto_assign_underfunded';
+  description = 'Fund every category with a negative month-balance to exactly $0. Mirrors YNAB\'s "Auto-Assign: Underfunded" button. Closed credit-card payment categories are excluded by default. Supports dry_run for previewing.';
+  inputSchema = BaseBudgetingInputSchema;
+
+  async execute(args: unknown): Promise<BudgetingResult> {
+    const input = this.validateArgs<BaseBudgetingInput>(args);
+
+    try {
+      const ctx = await loadBudgetingContext(this.client, input);
+      const filterOpts = buildFilterOptions(input, ctx.closedCcAccountNames);
+      const { kept, skipped } = filterCategories(ctx.categories, filterOpts);
+
+      const changes: PlannedChange[] = kept
+        .filter(c => c.balance < 0)
+        .map(c => ({
+          category_id: c.id,
+          category_name: c.name,
+          previous_budgeted: c.budgeted,
+          new_budgeted: c.budgeted + Math.abs(c.balance),
+          delta: Math.abs(c.balance),
+        }));
+
+      const result = await applyBudgetChanges(
+        this.client,
+        input.budget_id,
+        input.month,
+        changes,
+        { dry_run: input.dry_run }
+      );
+
+      const toBeBudgetedAfter = await refreshToBeBudgeted(
+        this.client,
+        input.budget_id,
+        input.month,
+        input.dry_run
+      );
+
+      return {
+        phase: 'assign_underfunded',
+        dry_run: input.dry_run,
+        categories_touched: result.applied,
+        total_moved_milliunits: result.total_moved_milliunits,
+        to_be_budgeted_before: { milliunits: ctx.toBeBudgetedBefore, formatted: this.formatCurrency(ctx.toBeBudgetedBefore) },
+        to_be_budgeted_after: wrapAmount(toBeBudgetedAfter),
+        skipped,
+        details: result.details,
+        failed: result.failed,
+      };
+    } catch (error) {
+      this.handleError(error, 'auto-assign underfunded');
+    }
+  }
+}

--- a/src/tools/budgeting/autoAssignUnderfunded.ts
+++ b/src/tools/budgeting/autoAssignUnderfunded.ts
@@ -7,7 +7,9 @@ import {
   loadBudgetingContext,
   refreshToBeBudgeted,
   wrapAmount,
+  formatAmount,
   type BaseBudgetingInput,
+  type BudgetingContext,
   type BudgetingResult,
 } from './shared.js';
 
@@ -21,9 +23,18 @@ export class AutoAssignUnderfundedTool extends YnabTool {
 
   async execute(args: unknown): Promise<BudgetingResult> {
     const input = this.validateArgs<BaseBudgetingInput>(args);
-
     try {
       const ctx = await loadBudgetingContext(this.client, input);
+      return await this.executeWithContext(input, ctx);
+    } catch (error) {
+      this.handleError(error, 'auto-assign underfunded');
+    }
+  }
+
+  /** Execute against a caller-supplied context. Lets compositions like
+   * AutoBalanceMonth reuse one context load across phases. */
+  async executeWithContext(input: BaseBudgetingInput, ctx: BudgetingContext): Promise<BudgetingResult> {
+    try {
       const filterOpts = buildFilterOptions(input, ctx.closedCcAccountNames);
       const { kept, skipped } = filterCategories(ctx.categories, filterOpts);
 
@@ -57,7 +68,7 @@ export class AutoAssignUnderfundedTool extends YnabTool {
         dry_run: input.dry_run,
         categories_touched: result.applied,
         total_moved_milliunits: result.total_moved_milliunits,
-        to_be_budgeted_before: { milliunits: ctx.toBeBudgetedBefore, formatted: this.formatCurrency(ctx.toBeBudgetedBefore) },
+        to_be_budgeted_before: formatAmount(ctx.toBeBudgetedBefore),
         to_be_budgeted_after: wrapAmount(toBeBudgetedAfter),
         skipped,
         details: result.details,

--- a/src/tools/budgeting/autoBalanceMonth.ts
+++ b/src/tools/budgeting/autoBalanceMonth.ts
@@ -1,7 +1,13 @@
 import { YnabTool } from '../base.js';
 import { AutoSweepPositivesTool } from './autoSweepPositives.js';
 import { AutoAssignUnderfundedTool } from './autoAssignUnderfunded.js';
-import { BaseBudgetingInputSchema, type BaseBudgetingInput, type BudgetingResult } from './shared.js';
+import {
+  BaseBudgetingInputSchema,
+  loadBudgetingContext,
+  type BaseBudgetingInput,
+  type BudgetingContext,
+  type BudgetingResult,
+} from './shared.js';
 
 export interface BalanceMonthResult {
   phase: 'balance_month';
@@ -10,12 +16,14 @@ export interface BalanceMonthResult {
   total_moved_milliunits: number;
 }
 
-/** Runs sweep-positives then assign-underfunded in order. One tool call
- * handles a full monthly allocation (positive activity flows back to RTA,
- * then RTA funds every negative balance to zero). */
+/** Runs sweep-positives then assign-underfunded in order. Loads accounts +
+ * month once for the sweep phase, then re-fetches only the month between
+ * phases (the PATCHes in sweep change `budgeted`/`activity` and the assign
+ * phase needs fresh balances). The account list is reused across phases to
+ * avoid a redundant GET /accounts call. */
 export class AutoBalanceMonthTool extends YnabTool {
   name = 'ynab_auto_balance_month';
-  description = 'Run sweep-positives then auto-assign-underfunded for a month in one call. Returns both phases\' details. Supports dry_run.';
+  description = 'Run sweep-positives then auto-assign-underfunded for a month in one call. Loads context once and reuses the account list across phases to conserve rate-limit budget. Supports dry_run.';
   inputSchema = BaseBudgetingInputSchema;
 
   async execute(args: unknown): Promise<BalanceMonthResult> {
@@ -25,11 +33,19 @@ export class AutoBalanceMonthTool extends YnabTool {
       const sweep = new AutoSweepPositivesTool(this.client);
       const assign = new AutoAssignUnderfundedTool(this.client);
 
-      const sweepResult = await sweep.execute(input);
-      const assignResult = await assign.execute(input);
+      // Phase 1: sweep. One context load (month + accounts).
+      const sweepCtx = await loadBudgetingContext(this.client, input);
+      const sweepResult = await sweep.executeWithContext(input, sweepCtx);
 
-      const phases = [sweepResult as BudgetingResult, assignResult as BudgetingResult];
+      // Phase 2: assign. Reuse the closed-CC account names from phase 1 —
+      // closed status doesn't change mid-run — but refresh the month so
+      // balances reflect the sweep PATCHes we just issued (unless dry_run).
+      const assignCtx = input.dry_run
+        ? sweepCtx
+        : await loadMonthOnlyContext(this.client, input, sweepCtx.closedCcAccountNames);
+      const assignResult = await assign.executeWithContext(input, assignCtx);
 
+      const phases = [sweepResult, assignResult];
       return {
         phase: 'balance_month',
         dry_run: input.dry_run,
@@ -40,4 +56,18 @@ export class AutoBalanceMonthTool extends YnabTool {
       this.handleError(error, 'auto-balance month');
     }
   }
+}
+
+async function loadMonthOnlyContext(
+  client: import('../../client/YNABClient.js').YNABClient,
+  input: Pick<BaseBudgetingInput, 'budget_id' | 'month'>,
+  closedCcAccountNames: string[]
+): Promise<BudgetingContext> {
+  const monthResponse = await client.getBudgetMonth(input.budget_id, input.month);
+  return {
+    month: monthResponse.month,
+    categories: monthResponse.month.categories,
+    closedCcAccountNames,
+    toBeBudgetedBefore: monthResponse.month.to_be_budgeted,
+  };
 }

--- a/src/tools/budgeting/autoBalanceMonth.ts
+++ b/src/tools/budgeting/autoBalanceMonth.ts
@@ -1,0 +1,43 @@
+import { YnabTool } from '../base.js';
+import { AutoSweepPositivesTool } from './autoSweepPositives.js';
+import { AutoAssignUnderfundedTool } from './autoAssignUnderfunded.js';
+import { BaseBudgetingInputSchema, type BaseBudgetingInput, type BudgetingResult } from './shared.js';
+
+export interface BalanceMonthResult {
+  phase: 'balance_month';
+  dry_run: boolean;
+  phases: BudgetingResult[];
+  total_moved_milliunits: number;
+}
+
+/** Runs sweep-positives then assign-underfunded in order. One tool call
+ * handles a full monthly allocation (positive activity flows back to RTA,
+ * then RTA funds every negative balance to zero). */
+export class AutoBalanceMonthTool extends YnabTool {
+  name = 'ynab_auto_balance_month';
+  description = 'Run sweep-positives then auto-assign-underfunded for a month in one call. Returns both phases\' details. Supports dry_run.';
+  inputSchema = BaseBudgetingInputSchema;
+
+  async execute(args: unknown): Promise<BalanceMonthResult> {
+    const input = this.validateArgs<BaseBudgetingInput>(args);
+
+    try {
+      const sweep = new AutoSweepPositivesTool(this.client);
+      const assign = new AutoAssignUnderfundedTool(this.client);
+
+      const sweepResult = await sweep.execute(input);
+      const assignResult = await assign.execute(input);
+
+      const phases = [sweepResult as BudgetingResult, assignResult as BudgetingResult];
+
+      return {
+        phase: 'balance_month',
+        dry_run: input.dry_run,
+        phases,
+        total_moved_milliunits: phases.reduce((s, p) => s + p.total_moved_milliunits, 0),
+      };
+    } catch (error) {
+      this.handleError(error, 'auto-balance month');
+    }
+  }
+}

--- a/src/tools/budgeting/autoSweepPositives.ts
+++ b/src/tools/budgeting/autoSweepPositives.ts
@@ -34,50 +34,48 @@ export class AutoSweepPositivesTool extends YnabTool {
     }
   }
 
-  /** Execute against a caller-supplied context; used by AutoBalanceMonth. */
+  /** Execute against a caller-supplied context; used by AutoBalanceMonth.
+   * Errors are NOT caught here — the outer `execute()` or the composing
+   * tool owns error wrapping so we don't double-wrap messages. */
   async executeWithContext(input: BaseBudgetingInput, ctx: BudgetingContext): Promise<BudgetingResult> {
-    try {
-      const filterOpts = buildFilterOptions(input, ctx.closedCcAccountNames, { skip_goal_carryover: true });
-      const { kept, skipped } = filterCategories(ctx.categories, filterOpts);
+    const filterOpts = buildFilterOptions(input, ctx.closedCcAccountNames, { skip_goal_carryover: true });
+    const { kept, skipped } = filterCategories(ctx.categories, filterOpts);
 
-      const changes: PlannedChange[] = kept
-        .filter(c => c.activity > 0)
-        .map(c => ({
-          category_id: c.id,
-          category_name: c.name,
-          previous_budgeted: c.budgeted,
-          new_budgeted: c.budgeted - c.activity,
-          delta: -c.activity,
-        }));
+    const changes: PlannedChange[] = kept
+      .filter(c => c.activity > 0)
+      .map(c => ({
+        category_id: c.id,
+        category_name: c.name,
+        previous_budgeted: c.budgeted,
+        new_budgeted: c.budgeted - c.activity,
+        delta: -c.activity,
+      }));
 
-      const result = await applyBudgetChanges(
-        this.client,
-        input.budget_id,
-        input.month,
-        changes,
-        { dry_run: input.dry_run }
-      );
+    const result = await applyBudgetChanges(
+      this.client,
+      input.budget_id,
+      input.month,
+      changes,
+      { dry_run: input.dry_run }
+    );
 
-      const toBeBudgetedAfter = await refreshToBeBudgeted(
-        this.client,
-        input.budget_id,
-        input.month,
-        input.dry_run
-      );
+    const toBeBudgetedAfter = await refreshToBeBudgeted(
+      this.client,
+      input.budget_id,
+      input.month,
+      input.dry_run
+    );
 
-      return {
-        phase: 'sweep_positives',
-        dry_run: input.dry_run,
-        categories_touched: result.applied,
-        total_moved_milliunits: result.total_moved_milliunits,
-        to_be_budgeted_before: formatAmount(ctx.toBeBudgetedBefore),
-        to_be_budgeted_after: wrapAmount(toBeBudgetedAfter),
-        skipped,
-        details: result.details,
-        failed: result.failed,
-      };
-    } catch (error) {
-      this.handleError(error, 'auto-sweep positives');
-    }
+    return {
+      phase: 'sweep_positives',
+      dry_run: input.dry_run,
+      categories_touched: result.applied,
+      total_moved_milliunits: result.total_moved_milliunits,
+      to_be_budgeted_before: formatAmount(ctx.toBeBudgetedBefore),
+      to_be_budgeted_after: wrapAmount(toBeBudgetedAfter),
+      skipped,
+      details: result.details,
+      failed: result.failed,
+    };
   }
 }

--- a/src/tools/budgeting/autoSweepPositives.ts
+++ b/src/tools/budgeting/autoSweepPositives.ts
@@ -1,0 +1,73 @@
+import { YnabTool } from '../base.js';
+import { filterCategories } from './categoryFilters.js';
+import { applyBudgetChanges, type PlannedChange } from './categoryBudgetApplier.js';
+import {
+  BaseBudgetingInputSchema,
+  buildFilterOptions,
+  loadBudgetingContext,
+  refreshToBeBudgeted,
+  wrapAmount,
+  type BaseBudgetingInput,
+  type BudgetingResult,
+} from './shared.js';
+
+/** Mirrors the YNAB workflow of sweeping positive-activity inflows
+ * (refunds, reimbursements, interest, etc.) back to Ready-to-Assign rather
+ * than leaving them piled in the spending category.
+ *
+ * Categories with a savings goal AND a positive prior-month carryover are
+ * preserved so in-flight savings aren't undone. */
+export class AutoSweepPositivesTool extends YnabTool {
+  name = 'ynab_auto_sweep_positives';
+  description = 'Sweep positive activity (refunds, reimbursements, interest) back to Ready-to-Assign by reducing `budgeted` by `activity`. Skips categories with a savings goal that already carry a positive balance from last month. Supports dry_run.';
+  inputSchema = BaseBudgetingInputSchema;
+
+  async execute(args: unknown): Promise<BudgetingResult> {
+    const input = this.validateArgs<BaseBudgetingInput>(args);
+
+    try {
+      const ctx = await loadBudgetingContext(this.client, input);
+      const filterOpts = buildFilterOptions(input, ctx.closedCcAccountNames, { skip_goal_carryover: true });
+      const { kept, skipped } = filterCategories(ctx.categories, filterOpts);
+
+      const changes: PlannedChange[] = kept
+        .filter(c => c.activity > 0)
+        .map(c => ({
+          category_id: c.id,
+          category_name: c.name,
+          previous_budgeted: c.budgeted,
+          new_budgeted: c.budgeted - c.activity,
+          delta: -c.activity,
+        }));
+
+      const result = await applyBudgetChanges(
+        this.client,
+        input.budget_id,
+        input.month,
+        changes,
+        { dry_run: input.dry_run }
+      );
+
+      const toBeBudgetedAfter = await refreshToBeBudgeted(
+        this.client,
+        input.budget_id,
+        input.month,
+        input.dry_run
+      );
+
+      return {
+        phase: 'sweep_positives',
+        dry_run: input.dry_run,
+        categories_touched: result.applied,
+        total_moved_milliunits: result.total_moved_milliunits,
+        to_be_budgeted_before: { milliunits: ctx.toBeBudgetedBefore, formatted: this.formatCurrency(ctx.toBeBudgetedBefore) },
+        to_be_budgeted_after: wrapAmount(toBeBudgetedAfter),
+        skipped,
+        details: result.details,
+        failed: result.failed,
+      };
+    } catch (error) {
+      this.handleError(error, 'auto-sweep positives');
+    }
+  }
+}

--- a/src/tools/budgeting/autoSweepPositives.ts
+++ b/src/tools/budgeting/autoSweepPositives.ts
@@ -7,7 +7,9 @@ import {
   loadBudgetingContext,
   refreshToBeBudgeted,
   wrapAmount,
+  formatAmount,
   type BaseBudgetingInput,
+  type BudgetingContext,
   type BudgetingResult,
 } from './shared.js';
 
@@ -24,9 +26,17 @@ export class AutoSweepPositivesTool extends YnabTool {
 
   async execute(args: unknown): Promise<BudgetingResult> {
     const input = this.validateArgs<BaseBudgetingInput>(args);
-
     try {
       const ctx = await loadBudgetingContext(this.client, input);
+      return await this.executeWithContext(input, ctx);
+    } catch (error) {
+      this.handleError(error, 'auto-sweep positives');
+    }
+  }
+
+  /** Execute against a caller-supplied context; used by AutoBalanceMonth. */
+  async executeWithContext(input: BaseBudgetingInput, ctx: BudgetingContext): Promise<BudgetingResult> {
+    try {
       const filterOpts = buildFilterOptions(input, ctx.closedCcAccountNames, { skip_goal_carryover: true });
       const { kept, skipped } = filterCategories(ctx.categories, filterOpts);
 
@@ -60,7 +70,7 @@ export class AutoSweepPositivesTool extends YnabTool {
         dry_run: input.dry_run,
         categories_touched: result.applied,
         total_moved_milliunits: result.total_moved_milliunits,
-        to_be_budgeted_before: { milliunits: ctx.toBeBudgetedBefore, formatted: this.formatCurrency(ctx.toBeBudgetedBefore) },
+        to_be_budgeted_before: formatAmount(ctx.toBeBudgetedBefore),
         to_be_budgeted_after: wrapAmount(toBeBudgetedAfter),
         skipped,
         details: result.details,

--- a/src/tools/budgeting/categoryBudgetApplier.ts
+++ b/src/tools/budgeting/categoryBudgetApplier.ts
@@ -1,0 +1,76 @@
+import type { YNABClient } from '../../client/YNABClient.js';
+
+/** A single pending change describing how one category's monthly `budgeted`
+ * should move. Produced by the planning stage of every batch budgeting tool
+ * and consumed here. */
+export interface PlannedChange {
+  category_id: string;
+  category_name: string;
+  previous_budgeted: number;
+  new_budgeted: number;
+  delta: number;
+}
+
+export interface AppliedChange extends PlannedChange {
+  status: 'applied' | 'planned' | 'skipped_noop' | 'failed';
+  error?: string;
+}
+
+export interface ApplyResult {
+  applied: number;
+  failed: Array<{ category_id: string; category_name: string; error: string }>;
+  total_moved_milliunits: number;
+  details: AppliedChange[];
+}
+
+export interface ApplyOptions {
+  /** If true, the planned changes are returned but no PATCHes are issued. */
+  dry_run?: boolean;
+}
+
+/** Apply a list of planned `budgeted` changes sequentially. Per-category
+ * failures are captured and reporting continues so a transient 500 on one
+ * category doesn't abort the rest of the monthly run. */
+export async function applyBudgetChanges(
+  client: YNABClient,
+  budgetId: string,
+  month: string,
+  changes: PlannedChange[],
+  options: ApplyOptions = {}
+): Promise<ApplyResult> {
+  const details: AppliedChange[] = [];
+  const failed: ApplyResult['failed'] = [];
+  let applied = 0;
+  let totalMoved = 0;
+
+  for (const change of changes) {
+    if (change.delta === 0) {
+      details.push({ ...change, status: 'skipped_noop' });
+      continue;
+    }
+
+    if (options.dry_run) {
+      details.push({ ...change, status: 'planned' });
+      applied += 1;
+      totalMoved += Math.abs(change.delta);
+      continue;
+    }
+
+    try {
+      await client.updateCategoryBudget(budgetId, change.category_id, month, change.new_budgeted);
+      details.push({ ...change, status: 'applied' });
+      applied += 1;
+      totalMoved += Math.abs(change.delta);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      details.push({ ...change, status: 'failed', error: message });
+      failed.push({
+        category_id: change.category_id,
+        category_name: change.category_name,
+        error: message,
+      });
+    }
+  }
+
+  return { applied, failed, total_moved_milliunits: totalMoved, details };
+}

--- a/src/tools/budgeting/categoryFilters.ts
+++ b/src/tools/budgeting/categoryFilters.ts
@@ -51,7 +51,11 @@ export interface FilteredCategory {
     | 'deleted'
     | 'ready_to_assign'
     | 'closed_cc'
-    | 'goal_carryover';
+    | 'goal_carryover'
+    /** Tool-specific: category did not exist in the month being copied from (assign-same-as-last-month). */
+    | 'no_prior_month'
+    /** Tool-specific: no outflow in the lookback window (assign-average-spend). */
+    | 'no_history';
 }
 
 /** YNAB's balance equation for a given month: balance = prior_carryover + budgeted + activity.

--- a/src/tools/budgeting/categoryFilters.ts
+++ b/src/tools/budgeting/categoryFilters.ts
@@ -1,0 +1,137 @@
+import type { YnabAccount, YnabCategory } from '../../types/index.js';
+
+/** YNAB account types that represent debt / credit-card-like accounts whose
+ * closed instances should, by default, have their payment categories
+ * excluded from batch budgeting. */
+export const CLOSED_CC_ACCOUNT_TYPES = [
+  'creditCard',
+  'lineOfCredit',
+  'otherDebt',
+  'mortgage',
+  'autoLoan',
+  'studentLoan',
+  'personalLoan',
+  'medicalDebt',
+] as const;
+
+type ClosedCcAccountType = typeof CLOSED_CC_ACCOUNT_TYPES[number];
+
+/** YNAB's internal category group housing "Inflow: Ready to Assign".
+ * Categories in this group are never budgetable via batch tools. */
+export const INTERNAL_MASTER_CATEGORY_GROUP = 'Internal Master Category';
+
+/** Category group where YNAB auto-creates one payment category per
+ * credit-card-like account. Closed-CC filtering only matches within this
+ * group so an ordinary category that happens to share a name with a closed
+ * account stays untouched. */
+export const CREDIT_CARD_PAYMENTS_GROUP = 'Credit Card Payments';
+
+export interface CategoryFilterOptions {
+  /** If set, only these categories are considered (everything else is skipped as `not_included`). Matched by id or name (case-insensitive). */
+  include?: string[];
+  /** Categories matching any entry are skipped as `excluded`. Matched by id or name (case-insensitive). */
+  exclude?: string[];
+  /** Skip `hidden: true` categories. Defaults to true. */
+  skip_hidden?: boolean;
+  /** Skip `deleted: true` categories. Forced to true regardless of value (safety). */
+  skip_deleted?: boolean;
+  /** Names of accounts considered closed CC/debt. Categories in the Credit Card Payments group with matching names are skipped as `closed_cc`. */
+  closed_cc_account_names?: string[];
+  /** Skip categories that have a savings goal and carry a positive balance over from the previous month. Default false; sweep-style tools opt in. */
+  skip_goal_carryover?: boolean;
+}
+
+export interface FilteredCategory {
+  category_id: string;
+  category_name: string;
+  reason:
+    | 'excluded'
+    | 'not_included'
+    | 'hidden'
+    | 'deleted'
+    | 'ready_to_assign'
+    | 'closed_cc'
+    | 'goal_carryover';
+}
+
+/** YNAB's balance equation for a given month: balance = prior_carryover + budgeted + activity.
+ * Invert it to recover the rolled-over balance from last month. */
+export function priorCarryover(category: YnabCategory): number {
+  return category.balance - category.budgeted - category.activity;
+}
+
+export interface FilterResult {
+  kept: YnabCategory[];
+  skipped: FilteredCategory[];
+}
+
+export function getClosedCcAccountNames(accounts: YnabAccount[]): string[] {
+  const debtTypes: Set<string> = new Set<ClosedCcAccountType>(CLOSED_CC_ACCOUNT_TYPES);
+  return accounts
+    .filter(a => a.closed && debtTypes.has(a.type))
+    .map(a => a.name);
+}
+
+function normalize(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function matchesAny(category: YnabCategory, list: string[] | undefined): boolean {
+  if (!list || list.length === 0) return false;
+  const normalized = list.map(normalize);
+  return normalized.includes(normalize(category.id)) || normalized.includes(normalize(category.name));
+}
+
+export function filterCategories(
+  categories: YnabCategory[],
+  options: CategoryFilterOptions = {}
+): FilterResult {
+  const skipHidden = options.skip_hidden ?? true;
+  const closedSet = new Set((options.closed_cc_account_names ?? []).map(normalize));
+
+  const kept: YnabCategory[] = [];
+  const skipped: FilteredCategory[] = [];
+
+  for (const c of categories) {
+    const entry = { category_id: c.id, category_name: c.name };
+
+    if (c.deleted) {
+      skipped.push({ ...entry, reason: 'deleted' });
+      continue;
+    }
+    if (c.category_group_name === INTERNAL_MASTER_CATEGORY_GROUP) {
+      skipped.push({ ...entry, reason: 'ready_to_assign' });
+      continue;
+    }
+    if (matchesAny(c, options.exclude)) {
+      skipped.push({ ...entry, reason: 'excluded' });
+      continue;
+    }
+    if (skipHidden && c.hidden) {
+      skipped.push({ ...entry, reason: 'hidden' });
+      continue;
+    }
+    if (
+      c.category_group_name === CREDIT_CARD_PAYMENTS_GROUP &&
+      closedSet.has(normalize(c.name))
+    ) {
+      skipped.push({ ...entry, reason: 'closed_cc' });
+      continue;
+    }
+    if (
+      options.skip_goal_carryover &&
+      c.goal_type != null &&
+      priorCarryover(c) > 0
+    ) {
+      skipped.push({ ...entry, reason: 'goal_carryover' });
+      continue;
+    }
+    if (options.include && options.include.length > 0 && !matchesAny(c, options.include)) {
+      skipped.push({ ...entry, reason: 'not_included' });
+      continue;
+    }
+    kept.push(c);
+  }
+
+  return { kept, skipped };
+}

--- a/src/tools/budgeting/index.ts
+++ b/src/tools/budgeting/index.ts
@@ -1,0 +1,6 @@
+export { AutoAssignUnderfundedTool } from './autoAssignUnderfunded.js';
+export { AutoSweepPositivesTool } from './autoSweepPositives.js';
+export { AutoBalanceMonthTool } from './autoBalanceMonth.js';
+export { ResetAvailableAmountsTool } from './resetAvailableAmounts.js';
+export { AssignSameAsLastMonthTool } from './assignSameAsLastMonth.js';
+export { AssignAverageSpendTool } from './assignAverageSpend.js';

--- a/src/tools/budgeting/monthMath.ts
+++ b/src/tools/budgeting/monthMath.ts
@@ -1,0 +1,20 @@
+/** Return the YNAB month string for the month immediately before the given
+ * YYYY-MM-01 value. Handles the January wrap-around. */
+export function previousMonth(month: string): string {
+  const [yearStr, monthStr] = month.split('-');
+  const year = Number(yearStr);
+  const m = Number(monthStr);
+  if (m === 1) return `${year - 1}-12-01`;
+  return `${year}-${String(m - 1).padStart(2, '0')}-01`;
+}
+
+/** Produce the N months preceding `month` (exclusive), in chronological order. */
+export function priorMonths(month: string, count: number): string[] {
+  const result: string[] = [];
+  let cursor = month;
+  for (let i = 0; i < count; i += 1) {
+    cursor = previousMonth(cursor);
+    result.unshift(cursor);
+  }
+  return result;
+}

--- a/src/tools/budgeting/resetAvailableAmounts.ts
+++ b/src/tools/budgeting/resetAvailableAmounts.ts
@@ -1,0 +1,70 @@
+import { YnabTool } from '../base.js';
+import { filterCategories } from './categoryFilters.js';
+import { applyBudgetChanges, type PlannedChange } from './categoryBudgetApplier.js';
+import {
+  BaseBudgetingInputSchema,
+  buildFilterOptions,
+  loadBudgetingContext,
+  refreshToBeBudgeted,
+  wrapAmount,
+  type BaseBudgetingInput,
+  type BudgetingResult,
+} from './shared.js';
+
+/** Mirrors YNAB's "Reset Available Amounts": set every category's balance
+ * to exactly $0 for the month. Positive balances flow back to RTA; negative
+ * balances are covered from RTA. Net change per category = -balance. */
+export class ResetAvailableAmountsTool extends YnabTool {
+  name = 'ynab_reset_available_amounts';
+  description = 'Set every filtered category\'s balance to $0 for the month by adjusting budgeted by -balance. Mirrors YNAB\'s "Reset Available Amounts". Supports dry_run.';
+  inputSchema = BaseBudgetingInputSchema;
+
+  async execute(args: unknown): Promise<BudgetingResult> {
+    const input = this.validateArgs<BaseBudgetingInput>(args);
+
+    try {
+      const ctx = await loadBudgetingContext(this.client, input);
+      const filterOpts = buildFilterOptions(input, ctx.closedCcAccountNames);
+      const { kept, skipped } = filterCategories(ctx.categories, filterOpts);
+
+      const changes: PlannedChange[] = kept
+        .filter(c => c.balance !== 0)
+        .map(c => ({
+          category_id: c.id,
+          category_name: c.name,
+          previous_budgeted: c.budgeted,
+          new_budgeted: c.budgeted - c.balance,
+          delta: -c.balance,
+        }));
+
+      const result = await applyBudgetChanges(
+        this.client,
+        input.budget_id,
+        input.month,
+        changes,
+        { dry_run: input.dry_run }
+      );
+
+      const toBeBudgetedAfter = await refreshToBeBudgeted(
+        this.client,
+        input.budget_id,
+        input.month,
+        input.dry_run
+      );
+
+      return {
+        phase: 'reset_available_amounts',
+        dry_run: input.dry_run,
+        categories_touched: result.applied,
+        total_moved_milliunits: result.total_moved_milliunits,
+        to_be_budgeted_before: { milliunits: ctx.toBeBudgetedBefore, formatted: this.formatCurrency(ctx.toBeBudgetedBefore) },
+        to_be_budgeted_after: wrapAmount(toBeBudgetedAfter),
+        skipped,
+        details: result.details,
+        failed: result.failed,
+      };
+    } catch (error) {
+      this.handleError(error, 'reset available amounts');
+    }
+  }
+}

--- a/src/tools/budgeting/resetAvailableAmounts.ts
+++ b/src/tools/budgeting/resetAvailableAmounts.ts
@@ -7,6 +7,7 @@ import {
   loadBudgetingContext,
   refreshToBeBudgeted,
   wrapAmount,
+  formatAmount,
   type BaseBudgetingInput,
   type BudgetingResult,
 } from './shared.js';
@@ -57,7 +58,7 @@ export class ResetAvailableAmountsTool extends YnabTool {
         dry_run: input.dry_run,
         categories_touched: result.applied,
         total_moved_milliunits: result.total_moved_milliunits,
-        to_be_budgeted_before: { milliunits: ctx.toBeBudgetedBefore, formatted: this.formatCurrency(ctx.toBeBudgetedBefore) },
+        to_be_budgeted_before: formatAmount(ctx.toBeBudgetedBefore),
         to_be_budgeted_after: wrapAmount(toBeBudgetedAfter),
         skipped,
         details: result.details,

--- a/src/tools/budgeting/shared.ts
+++ b/src/tools/budgeting/shared.ts
@@ -1,0 +1,108 @@
+import { z } from 'zod';
+import type { YNABClient } from '../../client/YNABClient.js';
+import type { YnabBudgetMonth, YnabCategory } from '../../types/index.js';
+import {
+  getClosedCcAccountNames,
+  type CategoryFilterOptions,
+  type FilterResult,
+} from './categoryFilters.js';
+import type { ApplyResult } from './categoryBudgetApplier.js';
+
+export const BaseBudgetingInputSchema = z.object({
+  budget_id: z.string().describe('The ID of the budget'),
+  month: z.string().regex(/^\d{4}-\d{2}-01$/).describe('The budget month in YYYY-MM-01 format (first day of month)'),
+  include_categories: z.array(z.string()).optional().describe('If set, only these categories are considered (matched by id or name, case-insensitive). Everything else is skipped.'),
+  exclude_categories: z.array(z.string()).optional().describe('Categories to skip (matched by id or name, case-insensitive).'),
+  skip_closed_cc_categories: z.boolean().optional().default(true).describe('Exclude Credit Card Payment categories whose matching CC/debt account is closed. Default true.'),
+  skip_hidden: z.boolean().optional().default(true).describe('Exclude hidden categories. Default true.'),
+  dry_run: z.boolean().optional().default(false).describe('Plan the changes without issuing any PATCHes. Default false.'),
+});
+
+export type BaseBudgetingInput = z.infer<typeof BaseBudgetingInputSchema>;
+
+export interface BudgetingContext {
+  month: YnabBudgetMonth;
+  categories: YnabCategory[];
+  closedCcAccountNames: string[];
+  toBeBudgetedBefore: number;
+}
+
+/** Load the data every batch-budgeting tool needs: month data (categories,
+ * to_be_budgeted) plus the account list used for closed-CC detection. */
+export async function loadBudgetingContext(
+  client: YNABClient,
+  input: Pick<BaseBudgetingInput, 'budget_id' | 'month' | 'skip_closed_cc_categories'>
+): Promise<BudgetingContext> {
+  const monthResponse = await client.getBudgetMonth(input.budget_id, input.month);
+  const month = monthResponse.month;
+
+  let closedCcAccountNames: string[] = [];
+  if (input.skip_closed_cc_categories) {
+    const accountsResponse = await client.getAccounts(input.budget_id);
+    closedCcAccountNames = getClosedCcAccountNames(accountsResponse.accounts);
+  }
+
+  return {
+    month,
+    categories: month.categories,
+    closedCcAccountNames,
+    toBeBudgetedBefore: month.to_be_budgeted,
+  };
+}
+
+/** Build filter options from base input + tool-specific extras. */
+export function buildFilterOptions(
+  input: BaseBudgetingInput,
+  closedCcAccountNames: string[],
+  extra: Pick<CategoryFilterOptions, 'skip_goal_carryover'> = {}
+): CategoryFilterOptions {
+  const opts: CategoryFilterOptions = {
+    skip_hidden: input.skip_hidden,
+    closed_cc_account_names: input.skip_closed_cc_categories ? closedCcAccountNames : [],
+    ...extra,
+  };
+  if (input.include_categories && input.include_categories.length > 0) {
+    opts.include = input.include_categories;
+  }
+  if (input.exclude_categories && input.exclude_categories.length > 0) {
+    opts.exclude = input.exclude_categories;
+  }
+  return opts;
+}
+
+export interface BudgetingResult {
+  phase: string;
+  dry_run: boolean;
+  categories_touched: number;
+  total_moved_milliunits: number;
+  to_be_budgeted_before: { milliunits: number; formatted: string };
+  to_be_budgeted_after: { milliunits: number; formatted: string } | null;
+  skipped: FilterResult['skipped'];
+  details: ApplyResult['details'];
+  failed: ApplyResult['failed'];
+}
+
+/** Re-fetch `to_be_budgeted` after applying so callers get an authoritative
+ * post-run figure. Skipped on dry_run. */
+export async function refreshToBeBudgeted(
+  client: YNABClient,
+  budgetId: string,
+  month: string,
+  dryRun: boolean
+): Promise<number | null> {
+  if (dryRun) return null;
+  const response = await client.getBudgetMonth(budgetId, month);
+  return response.month.to_be_budgeted;
+}
+
+export function formatMilliunits(milliunits: number): string {
+  const dollars = milliunits / 1000;
+  return dollars < 0
+    ? `-$${Math.abs(dollars).toFixed(2)}`
+    : `$${dollars.toFixed(2)}`;
+}
+
+export function wrapAmount(milliunits: number | null): { milliunits: number; formatted: string } | null {
+  if (milliunits === null) return null;
+  return { milliunits, formatted: formatMilliunits(milliunits) };
+}

--- a/src/tools/budgeting/shared.ts
+++ b/src/tools/budgeting/shared.ts
@@ -102,7 +102,16 @@ export function formatMilliunits(milliunits: number): string {
     : `$${dollars.toFixed(2)}`;
 }
 
-export function wrapAmount(milliunits: number | null): { milliunits: number; formatted: string } | null {
+export interface FormattedAmount {
+  milliunits: number;
+  formatted: string;
+}
+
+export function wrapAmount(milliunits: number | null): FormattedAmount | null {
   if (milliunits === null) return null;
+  return { milliunits, formatted: formatMilliunits(milliunits) };
+}
+
+export function formatAmount(milliunits: number): FormattedAmount {
   return { milliunits, formatted: formatMilliunits(milliunits) };
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -35,6 +35,14 @@ import { DeleteScheduledTransactionTool } from './scheduled/deleteScheduledTrans
 import { RecommendCategoryAllocationTool } from './analysis/recommendCategoryAllocation.js';
 import { AnalyzeSpendingPatternsTool } from './analysis/analyzeSpendingPatterns.js';
 import { DistributeToBebudgetedTool } from './analysis/distributeToBebudgeted.js';
+import {
+  AutoAssignUnderfundedTool,
+  AutoSweepPositivesTool,
+  AutoBalanceMonthTool,
+  ResetAvailableAmountsTool,
+  AssignSameAsLastMonthTool,
+  AssignAverageSpendTool,
+} from './budgeting/index.js';
 
 import type { Tool } from '../types/index.js';
 import type { YNABClient } from '../client/YNABClient.js';
@@ -94,6 +102,14 @@ export function registerTools(client: YNABClient): Tool[] {
     new RecommendCategoryAllocationTool(client),
     new AnalyzeSpendingPatternsTool(client),
     new DistributeToBebudgetedTool(client),
+
+    // Batch monthly budgeting tools
+    new AutoAssignUnderfundedTool(client),
+    new AutoSweepPositivesTool(client),
+    new AutoBalanceMonthTool(client),
+    new ResetAvailableAmountsTool(client),
+    new AssignSameAsLastMonthTool(client),
+    new AssignAverageSpendTool(client),
   ];
 }
 

--- a/tests/server/toolRegistry.test.ts
+++ b/tests/server/toolRegistry.test.ts
@@ -178,6 +178,20 @@ describe('Tool Registry', () => {
     });
   });
 
+  describe('Budgeting tools', () => {
+    it.each([
+      'ynab_auto_assign_underfunded',
+      'ynab_auto_sweep_positives',
+      'ynab_auto_balance_month',
+      'ynab_reset_available_amounts',
+      'ynab_assign_same_as_last_month',
+      'ynab_assign_average_spend',
+    ])('registers %s', (name) => {
+      const tool = registeredTools.find(t => t.name === name);
+      expect(tool).toBeDefined();
+    });
+  });
+
   describe('Tool uniqueness', () => {
     it('all tool names are unique', () => {
       const names = registeredTools.map(t => t.name);

--- a/tests/tools/budgeting/assignAverageSpend.test.ts
+++ b/tests/tools/budgeting/assignAverageSpend.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { AssignAverageSpendTool } from '../../../src/tools/budgeting/assignAverageSpend.js';
+import { createMockClient, type MockYNABClient } from '../../helpers/mockClient.js';
+import { createMockCategory } from '../../helpers/fixtures.js';
+
+function monthResponse(month: string, categories: any[], to_be_budgeted = 0) {
+  return {
+    month: { month, note: null, income: 0, budgeted: 0, activity: 0, to_be_budgeted, age_of_money: null, deleted: false, categories },
+    server_knowledge: 1,
+  };
+}
+
+describe('AssignAverageSpendTool', () => {
+  let client: MockYNABClient;
+  let tool: AssignAverageSpendTool;
+
+  beforeEach(() => {
+    client = createMockClient();
+    tool = new AssignAverageSpendTool(client as any);
+  });
+
+  it('sets budgeted to mean of absolute activity across lookback months', async () => {
+    // 3 months of Food spending: -60, -90, -120 -> avg = 90
+    const catId = 'c-food';
+    const foodIn = (activity: number) => createMockCategory({
+      id: catId, name: 'Food', category_group_name: 'Spending', budgeted: 0, activity, balance: 0,
+    });
+    client.getBudgetMonth.mockImplementation(async (_b, m) => {
+      if (m === '2024-04-01') return monthResponse(m, [foodIn(0)]);
+      if (m === '2024-03-01') return monthResponse(m, [foodIn(-120000)]);
+      if (m === '2024-02-01') return monthResponse(m, [foodIn(-90000)]);
+      if (m === '2024-01-01') return monthResponse(m, [foodIn(-60000)]);
+      return monthResponse(m, []);
+    });
+
+    const r = await tool.execute({
+      budget_id: 'b1',
+      month: '2024-04-01',
+      lookback_months: 3,
+      skip_closed_cc_categories: false,
+    });
+
+    expect(client.updateCategoryBudget).toHaveBeenCalledWith('b1', catId, '2024-04-01', 90000);
+    expect(r.lookback_used).toBe(3);
+  });
+
+  it('uses available history when fewer than requested lookback months exist', async () => {
+    const catId = 'c-food';
+    const foodIn = (activity: number) => createMockCategory({
+      id: catId, name: 'Food', category_group_name: 'Spending', budgeted: 0, activity, balance: 0,
+    });
+    client.getBudgetMonth.mockImplementation(async (_b, m) => {
+      if (m === '2024-04-01') return monthResponse(m, [foodIn(0)]);
+      if (m === '2024-03-01') return monthResponse(m, [foodIn(-100000)]);
+      if (m === '2024-02-01') return monthResponse(m, [foodIn(-200000)]);
+      // no January
+      if (m === '2024-01-01') return monthResponse(m, []);
+      return monthResponse(m, []);
+    });
+
+    const r = await tool.execute({
+      budget_id: 'b1',
+      month: '2024-04-01',
+      lookback_months: 3,
+      skip_closed_cc_categories: false,
+    });
+
+    // Avg over the 2 months where data exists: (100 + 200) / 2 = 150
+    expect(client.updateCategoryBudget).toHaveBeenCalledWith('b1', catId, '2024-04-01', 150000);
+    expect(r.lookback_used).toBe(2);
+  });
+
+  it('ignores positive activity (refunds) so averages reflect net spending', async () => {
+    const catId = 'c-food';
+    const foodIn = (activity: number) => createMockCategory({
+      id: catId, name: 'Food', category_group_name: 'Spending', budgeted: 0, activity, balance: 0,
+    });
+    client.getBudgetMonth.mockImplementation(async (_b, m) => {
+      if (m === '2024-04-01') return monthResponse(m, [foodIn(0)]);
+      if (m === '2024-03-01') return monthResponse(m, [foodIn(-100000)]);
+      if (m === '2024-02-01') return monthResponse(m, [foodIn(20000)]); // refund month
+      return monthResponse(m, []);
+    });
+
+    const r = await tool.execute({
+      budget_id: 'b1',
+      month: '2024-04-01',
+      lookback_months: 2,
+      skip_closed_cc_categories: false,
+    });
+
+    // Only the spend month counts: (100) / 1 = 100
+    expect(client.updateCategoryBudget).toHaveBeenCalledWith('b1', catId, '2024-04-01', 100000);
+    expect(r.lookback_used).toBe(1);
+  });
+
+  it('skips category with zero history', async () => {
+    const catId = 'c-food';
+    const foodIn = (activity: number) => createMockCategory({
+      id: catId, name: 'Food', category_group_name: 'Spending', budgeted: 10000, activity, balance: 0,
+    });
+    client.getBudgetMonth.mockImplementation(async (_b, m) => {
+      if (m === '2024-04-01') return monthResponse(m, [foodIn(0)]);
+      return monthResponse(m, []);
+    });
+
+    await tool.execute({
+      budget_id: 'b1',
+      month: '2024-04-01',
+      lookback_months: 3,
+      skip_closed_cc_categories: false,
+    });
+
+    expect(client.updateCategoryBudget).not.toHaveBeenCalled();
+  });
+});

--- a/tests/tools/budgeting/assignAverageSpend.test.ts
+++ b/tests/tools/budgeting/assignAverageSpend.test.ts
@@ -94,7 +94,7 @@ describe('AssignAverageSpendTool', () => {
     expect(r.lookback_used).toBe(1);
   });
 
-  it('skips category with zero history', async () => {
+  it('skips category with zero history and surfaces it in skipped with reason=no_history', async () => {
     const catId = 'c-food';
     const foodIn = (activity: number) => createMockCategory({
       id: catId, name: 'Food', category_group_name: 'Spending', budgeted: 10000, activity, balance: 0,
@@ -104,7 +104,7 @@ describe('AssignAverageSpendTool', () => {
       return monthResponse(m, []);
     });
 
-    await tool.execute({
+    const r = await tool.execute({
       budget_id: 'b1',
       month: '2024-04-01',
       lookback_months: 3,
@@ -112,5 +112,6 @@ describe('AssignAverageSpendTool', () => {
     });
 
     expect(client.updateCategoryBudget).not.toHaveBeenCalled();
+    expect(r.skipped.some(s => s.category_id === catId && s.reason === 'no_history')).toBe(true);
   });
 });

--- a/tests/tools/budgeting/assignSameAsLastMonth.test.ts
+++ b/tests/tools/budgeting/assignSameAsLastMonth.test.ts
@@ -61,7 +61,7 @@ describe('AssignSameAsLastMonthTool', () => {
 
     expect(client.updateCategoryBudget).toHaveBeenCalledTimes(1);
     expect(client.updateCategoryBudget).toHaveBeenCalledWith('b1', 'c-food', '2024-02-01', 60000);
-    expect(r.skipped.some(s => s.category_id === 'c-new' && s.reason === 'excluded')).toBe(true);
+    expect(r.skipped.some(s => s.category_id === 'c-new' && s.reason === 'no_prior_month')).toBe(true);
   });
 
   it('no-ops categories already matching previous month', async () => {

--- a/tests/tools/budgeting/assignSameAsLastMonth.test.ts
+++ b/tests/tools/budgeting/assignSameAsLastMonth.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { AssignSameAsLastMonthTool } from '../../../src/tools/budgeting/assignSameAsLastMonth.js';
+import { previousMonth } from '../../../src/tools/budgeting/monthMath.js';
+import { createMockClient, type MockYNABClient } from '../../helpers/mockClient.js';
+import { createMockCategory } from '../../helpers/fixtures.js';
+
+function monthResponse(categories: any[], to_be_budgeted = 0) {
+  return {
+    month: {
+      month: '2024-02-01', note: null, income: 0, budgeted: 0, activity: 0,
+      to_be_budgeted, age_of_money: null, deleted: false, categories,
+    },
+    server_knowledge: 1,
+  };
+}
+
+describe('previousMonth', () => {
+  it('handles January → previous December', () => {
+    expect(previousMonth('2024-01-01')).toBe('2023-12-01');
+  });
+  it('handles mid-year months', () => {
+    expect(previousMonth('2024-07-01')).toBe('2024-06-01');
+  });
+});
+
+describe('AssignSameAsLastMonthTool', () => {
+  let client: MockYNABClient;
+  let tool: AssignSameAsLastMonthTool;
+
+  beforeEach(() => {
+    client = createMockClient();
+    tool = new AssignSameAsLastMonthTool(client as any);
+  });
+
+  it('copies previous month budgeted per category matched by id', async () => {
+    const prev = [
+      createMockCategory({ id: 'c-food', name: 'Food', category_group_name: 'Spending', budgeted: 60000 }),
+      createMockCategory({ id: 'c-gas', name: 'Gas', category_group_name: 'Spending', budgeted: 40000 }),
+    ];
+    const cur = [
+      createMockCategory({ id: 'c-food', name: 'Food', category_group_name: 'Spending', budgeted: 0 }),
+      createMockCategory({ id: 'c-gas', name: 'Gas', category_group_name: 'Spending', budgeted: 10000 }),
+    ];
+    client.getBudgetMonth.mockImplementation(async (_b, m) => monthResponse(m === '2024-02-01' ? cur : prev));
+
+    await tool.execute({ budget_id: 'b1', month: '2024-02-01', skip_closed_cc_categories: false });
+
+    expect(client.updateCategoryBudget).toHaveBeenCalledWith('b1', 'c-food', '2024-02-01', 60000);
+    expect(client.updateCategoryBudget).toHaveBeenCalledWith('b1', 'c-gas', '2024-02-01', 40000);
+  });
+
+  it('skips categories absent from previous month (new categories)', async () => {
+    const prev = [createMockCategory({ id: 'c-food', name: 'Food', category_group_name: 'Spending', budgeted: 60000 })];
+    const cur = [
+      createMockCategory({ id: 'c-food', name: 'Food', category_group_name: 'Spending', budgeted: 0 }),
+      createMockCategory({ id: 'c-new', name: 'New', category_group_name: 'Spending', budgeted: 0 }),
+    ];
+    client.getBudgetMonth.mockImplementation(async (_b, m) => monthResponse(m === '2024-02-01' ? cur : prev));
+
+    const r = await tool.execute({ budget_id: 'b1', month: '2024-02-01', skip_closed_cc_categories: false });
+
+    expect(client.updateCategoryBudget).toHaveBeenCalledTimes(1);
+    expect(client.updateCategoryBudget).toHaveBeenCalledWith('b1', 'c-food', '2024-02-01', 60000);
+    expect(r.skipped.some(s => s.category_id === 'c-new' && s.reason === 'excluded')).toBe(true);
+  });
+
+  it('no-ops categories already matching previous month', async () => {
+    const prev = [createMockCategory({ id: 'c-food', name: 'Food', category_group_name: 'Spending', budgeted: 60000 })];
+    const cur = [createMockCategory({ id: 'c-food', name: 'Food', category_group_name: 'Spending', budgeted: 60000 })];
+    client.getBudgetMonth.mockImplementation(async (_b, m) => monthResponse(m === '2024-02-01' ? cur : prev));
+
+    const r = await tool.execute({ budget_id: 'b1', month: '2024-02-01', skip_closed_cc_categories: false });
+    expect(client.updateCategoryBudget).not.toHaveBeenCalled();
+    expect(r.categories_touched).toBe(0);
+  });
+
+  it('reports phase name', async () => {
+    client.getBudgetMonth.mockResolvedValue(monthResponse([]));
+    const r = await tool.execute({ budget_id: 'b1', month: '2024-02-01', skip_closed_cc_categories: false });
+    expect(r.phase).toBe('assign_same_as_last_month');
+  });
+});

--- a/tests/tools/budgeting/autoAssignUnderfunded.test.ts
+++ b/tests/tools/budgeting/autoAssignUnderfunded.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { AutoAssignUnderfundedTool } from '../../../src/tools/budgeting/autoAssignUnderfunded.js';
+import { createMockClient, type MockYNABClient } from '../../helpers/mockClient.js';
+import { createMockCategory, createMockAccount } from '../../helpers/fixtures.js';
+
+function monthResponse(categories: any[], to_be_budgeted = 0) {
+  return {
+    month: {
+      month: '2024-01-01',
+      note: null,
+      income: 0,
+      budgeted: 0,
+      activity: 0,
+      to_be_budgeted,
+      age_of_money: null,
+      deleted: false,
+      categories,
+    },
+    server_knowledge: 1,
+  };
+}
+
+describe('AutoAssignUnderfundedTool', () => {
+  let client: MockYNABClient;
+  let tool: AutoAssignUnderfundedTool;
+
+  beforeEach(() => {
+    client = createMockClient();
+    tool = new AutoAssignUnderfundedTool(client as any);
+  });
+
+  it('patches each underfunded category up to balance=0', async () => {
+    const underfunded = createMockCategory({
+      id: 'c-under', name: 'Groceries', category_group_name: 'Spending',
+      budgeted: 50000, activity: -120000, balance: -70000,
+    });
+    const ok = createMockCategory({
+      id: 'c-ok', name: 'Rent', category_group_name: 'Bills',
+      budgeted: 200000, activity: -200000, balance: 0,
+    });
+    client.getBudgetMonth.mockResolvedValue(monthResponse([underfunded, ok], 500000));
+
+    const result = await tool.execute({
+      budget_id: 'b1',
+      month: '2024-01-01',
+      skip_closed_cc_categories: false,
+    });
+
+    expect(client.updateCategoryBudget).toHaveBeenCalledTimes(1);
+    expect(client.updateCategoryBudget).toHaveBeenCalledWith(
+      'b1', 'c-under', '2024-01-01', 50000 + 70000 // previous + |balance|
+    );
+    expect(result.categories_touched).toBe(1);
+    expect(result.total_moved_milliunits).toBe(70000);
+    expect(result.phase).toBe('assign_underfunded');
+  });
+
+  it('is idempotent when every category is already funded', async () => {
+    const ok = createMockCategory({
+      id: 'c-ok', name: 'Rent', category_group_name: 'Bills',
+      budgeted: 200000, activity: -200000, balance: 0,
+    });
+    client.getBudgetMonth.mockResolvedValue(monthResponse([ok]));
+
+    const result = await tool.execute({
+      budget_id: 'b1',
+      month: '2024-01-01',
+      skip_closed_cc_categories: false,
+    });
+
+    expect(client.updateCategoryBudget).not.toHaveBeenCalled();
+    expect(result.categories_touched).toBe(0);
+  });
+
+  it('dry_run plans without PATCHing and skips the post-refresh GET', async () => {
+    const underfunded = createMockCategory({
+      id: 'c-under', name: 'Groceries', category_group_name: 'Spending',
+      budgeted: 0, activity: -50000, balance: -50000,
+    });
+    client.getBudgetMonth.mockResolvedValue(monthResponse([underfunded]));
+
+    const result = await tool.execute({
+      budget_id: 'b1',
+      month: '2024-01-01',
+      dry_run: true,
+      skip_closed_cc_categories: false,
+    });
+
+    expect(client.updateCategoryBudget).not.toHaveBeenCalled();
+    expect(result.dry_run).toBe(true);
+    expect(result.to_be_budgeted_after).toBeNull();
+    expect(client.getBudgetMonth).toHaveBeenCalledTimes(1); // no refresh
+    expect(result.details[0]!.status).toBe('planned');
+  });
+
+  it('skips closed-CC payment categories by default', async () => {
+    client.getAccounts.mockResolvedValue({
+      accounts: [createMockAccount({ name: 'Closed Amex', type: 'creditCard', closed: true })],
+      server_knowledge: 1,
+    });
+    const ccUnder = createMockCategory({
+      id: 'c-cc-closed', name: 'Closed Amex', category_group_name: 'Credit Card Payments',
+      budgeted: 0, activity: 0, balance: -10000,
+    });
+    const regUnder = createMockCategory({
+      id: 'c-food', name: 'Food', category_group_name: 'Spending',
+      budgeted: 0, activity: -30000, balance: -30000,
+    });
+    client.getBudgetMonth.mockResolvedValue(monthResponse([ccUnder, regUnder]));
+
+    const result = await tool.execute({ budget_id: 'b1', month: '2024-01-01' });
+
+    expect(client.updateCategoryBudget).toHaveBeenCalledTimes(1);
+    expect(client.updateCategoryBudget).toHaveBeenCalledWith('b1', 'c-food', '2024-01-01', 30000);
+    expect(result.skipped.some(s => s.category_id === 'c-cc-closed' && s.reason === 'closed_cc')).toBe(true);
+  });
+
+  it('include list narrows work; exclude list removes funded candidates', async () => {
+    const c1 = createMockCategory({ id: 'c-1', name: 'One', category_group_name: 'G', budgeted: 0, activity: -10000, balance: -10000 });
+    const c2 = createMockCategory({ id: 'c-2', name: 'Two', category_group_name: 'G', budgeted: 0, activity: -20000, balance: -20000 });
+    const c3 = createMockCategory({ id: 'c-3', name: 'Three', category_group_name: 'G', budgeted: 0, activity: -30000, balance: -30000 });
+    client.getBudgetMonth.mockResolvedValue(monthResponse([c1, c2, c3]));
+
+    await tool.execute({
+      budget_id: 'b1',
+      month: '2024-01-01',
+      include_categories: ['c-1', 'Two'],
+      exclude_categories: ['c-1'],
+      skip_closed_cc_categories: false,
+    });
+
+    expect(client.updateCategoryBudget).toHaveBeenCalledTimes(1);
+    expect(client.updateCategoryBudget).toHaveBeenCalledWith('b1', 'c-2', '2024-01-01', 20000);
+  });
+
+  it('surfaces per-category failures without aborting the batch', async () => {
+    const c1 = createMockCategory({ id: 'c-1', name: 'One', category_group_name: 'G', budgeted: 0, activity: -10000, balance: -10000 });
+    const c2 = createMockCategory({ id: 'c-2', name: 'Two', category_group_name: 'G', budgeted: 0, activity: -20000, balance: -20000 });
+    client.getBudgetMonth.mockResolvedValue(monthResponse([c1, c2]));
+    client.updateCategoryBudget.mockImplementation(async (_b, id) => {
+      if (id === 'c-1') throw new Error('rate_limit');
+      return { category: { id } };
+    });
+
+    const result = await tool.execute({ budget_id: 'b1', month: '2024-01-01', skip_closed_cc_categories: false });
+
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0]!.category_id).toBe('c-1');
+    expect(result.categories_touched).toBe(1);
+  });
+});

--- a/tests/tools/budgeting/autoAssignUnderfunded.test.ts
+++ b/tests/tools/budgeting/autoAssignUnderfunded.test.ts
@@ -133,6 +133,18 @@ describe('AutoAssignUnderfundedTool', () => {
     expect(client.updateCategoryBudget).toHaveBeenCalledWith('b1', 'c-2', '2024-01-01', 20000);
   });
 
+  it('wraps errors exactly once (no "failed: failed:" double-wrap)', async () => {
+    client.getBudgetMonth.mockRejectedValue(new Error('boom'));
+    try {
+      await tool.execute({ budget_id: 'b1', month: '2024-01-01', skip_closed_cc_categories: false });
+      expect.fail('expected error');
+    } catch (e) {
+      const msg = (e as Error).message;
+      const occurrences = (msg.match(/auto-assign underfunded failed/g) ?? []).length;
+      expect(occurrences).toBe(1);
+    }
+  });
+
   it('surfaces per-category failures without aborting the batch', async () => {
     const c1 = createMockCategory({ id: 'c-1', name: 'One', category_group_name: 'G', budgeted: 0, activity: -10000, balance: -10000 });
     const c2 = createMockCategory({ id: 'c-2', name: 'Two', category_group_name: 'G', budgeted: 0, activity: -20000, balance: -20000 });

--- a/tests/tools/budgeting/autoBalanceMonth.test.ts
+++ b/tests/tools/budgeting/autoBalanceMonth.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { AutoBalanceMonthTool } from '../../../src/tools/budgeting/autoBalanceMonth.js';
+import { createMockClient, type MockYNABClient } from '../../helpers/mockClient.js';
+import { createMockCategory } from '../../helpers/fixtures.js';
+
+function monthResponse(categories: any[], to_be_budgeted = 0) {
+  return {
+    month: {
+      month: '2024-01-01', note: null, income: 0, budgeted: 0, activity: 0,
+      to_be_budgeted, age_of_money: null, deleted: false, categories,
+    },
+    server_knowledge: 1,
+  };
+}
+
+describe('AutoBalanceMonthTool', () => {
+  let client: MockYNABClient;
+  let tool: AutoBalanceMonthTool;
+
+  beforeEach(() => {
+    client = createMockClient();
+    tool = new AutoBalanceMonthTool(client as any);
+  });
+
+  it('runs sweep first then assign, reporting both phases', async () => {
+    const refund = createMockCategory({
+      id: 'c-refund', name: 'Amazon', category_group_name: 'Shopping',
+      budgeted: 0, activity: 10000, balance: 10000,
+    });
+    const underfunded = createMockCategory({
+      id: 'c-under', name: 'Groceries', category_group_name: 'Spending',
+      budgeted: 0, activity: -40000, balance: -40000,
+    });
+    client.getBudgetMonth.mockResolvedValue(monthResponse([refund, underfunded], 100000));
+
+    const result = await tool.execute({ budget_id: 'b1', month: '2024-01-01', skip_closed_cc_categories: false });
+
+    expect(result.phases.map(p => p.phase)).toEqual(['sweep_positives', 'assign_underfunded']);
+    const sweep = result.phases[0]!;
+    const assign = result.phases[1]!;
+    expect(sweep.categories_touched).toBe(1);
+    expect(assign.categories_touched).toBe(1);
+    expect(result.total_moved_milliunits).toBe(50000); // 10k sweep + 40k assign
+  });
+
+  it('dry_run bubbles through to both phases', async () => {
+    const refund = createMockCategory({
+      id: 'c-refund', name: 'Amazon', category_group_name: 'Shopping',
+      budgeted: 0, activity: 10000, balance: 10000,
+    });
+    client.getBudgetMonth.mockResolvedValue(monthResponse([refund]));
+
+    const result = await tool.execute({ budget_id: 'b1', month: '2024-01-01', dry_run: true, skip_closed_cc_categories: false });
+
+    expect(client.updateCategoryBudget).not.toHaveBeenCalled();
+    expect(result.phases.every(p => p.dry_run)).toBe(true);
+  });
+});

--- a/tests/tools/budgeting/autoBalanceMonth.test.ts
+++ b/tests/tools/budgeting/autoBalanceMonth.test.ts
@@ -43,6 +43,22 @@ describe('AutoBalanceMonthTool', () => {
     expect(result.total_moved_milliunits).toBe(50000); // 10k sweep + 40k assign
   });
 
+  it('loads accounts once across both phases (rate-limit conservation)', async () => {
+    const refund = createMockCategory({
+      id: 'c-refund', name: 'Amazon', category_group_name: 'Shopping',
+      budgeted: 0, activity: 10000, balance: 10000,
+    });
+    const underfunded = createMockCategory({
+      id: 'c-under', name: 'Groceries', category_group_name: 'Spending',
+      budgeted: 0, activity: -40000, balance: -40000,
+    });
+    client.getBudgetMonth.mockResolvedValue(monthResponse([refund, underfunded]));
+
+    await tool.execute({ budget_id: 'b1', month: '2024-01-01' });
+
+    expect(client.getAccounts).toHaveBeenCalledTimes(1);
+  });
+
   it('dry_run bubbles through to both phases', async () => {
     const refund = createMockCategory({
       id: 'c-refund', name: 'Amazon', category_group_name: 'Shopping',

--- a/tests/tools/budgeting/autoSweepPositives.test.ts
+++ b/tests/tools/budgeting/autoSweepPositives.test.ts
@@ -95,4 +95,16 @@ describe('AutoSweepPositivesTool', () => {
     expect(result.dry_run).toBe(true);
     expect(result.details[0]!.status).toBe('planned');
   });
+
+  it('wraps errors exactly once (no "failed: failed:" double-wrap)', async () => {
+    client.getBudgetMonth.mockRejectedValue(new Error('boom'));
+    try {
+      await tool.execute({ budget_id: 'b1', month: '2024-01-01', skip_closed_cc_categories: false });
+      expect.fail('expected error');
+    } catch (e) {
+      const msg = (e as Error).message;
+      const occurrences = (msg.match(/auto-sweep positives failed/g) ?? []).length;
+      expect(occurrences).toBe(1);
+    }
+  });
 });

--- a/tests/tools/budgeting/autoSweepPositives.test.ts
+++ b/tests/tools/budgeting/autoSweepPositives.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { AutoSweepPositivesTool } from '../../../src/tools/budgeting/autoSweepPositives.js';
+import { createMockClient, type MockYNABClient } from '../../helpers/mockClient.js';
+import { createMockCategory } from '../../helpers/fixtures.js';
+
+function monthResponse(categories: any[], to_be_budgeted = 0) {
+  return {
+    month: {
+      month: '2024-01-01', note: null, income: 0, budgeted: 0, activity: 0,
+      to_be_budgeted, age_of_money: null, deleted: false, categories,
+    },
+    server_knowledge: 1,
+  };
+}
+
+describe('AutoSweepPositivesTool', () => {
+  let client: MockYNABClient;
+  let tool: AutoSweepPositivesTool;
+
+  beforeEach(() => {
+    client = createMockClient();
+    tool = new AutoSweepPositivesTool(client as any);
+  });
+
+  it('sweeps each category with positive activity back to RTA', async () => {
+    const refund = createMockCategory({
+      id: 'c-refund', name: 'Amazon', category_group_name: 'Shopping',
+      budgeted: 0, activity: 15000, balance: 15000,
+    });
+    const spend = createMockCategory({
+      id: 'c-spend', name: 'Food', category_group_name: 'Spending',
+      budgeted: 50000, activity: -30000, balance: 20000,
+    });
+    client.getBudgetMonth.mockResolvedValue(monthResponse([refund, spend]));
+
+    const result = await tool.execute({ budget_id: 'b1', month: '2024-01-01', skip_closed_cc_categories: false });
+
+    expect(client.updateCategoryBudget).toHaveBeenCalledTimes(1);
+    expect(client.updateCategoryBudget).toHaveBeenCalledWith('b1', 'c-refund', '2024-01-01', -15000);
+    expect(result.phase).toBe('sweep_positives');
+    expect(result.categories_touched).toBe(1);
+    expect(result.total_moved_milliunits).toBe(15000);
+  });
+
+  it('preserves savings categories (goal + prior-month carryover)', async () => {
+    const savings = createMockCategory({
+      id: 'c-save', name: 'Vacation', category_group_name: 'Savings',
+      goal_type: 'TB',
+      // prior_carryover = 500 - 100 - 50 = 350 (positive)
+      budgeted: 100000, activity: 50000, balance: 500000,
+    });
+    client.getBudgetMonth.mockResolvedValue(monthResponse([savings]));
+
+    const result = await tool.execute({ budget_id: 'b1', month: '2024-01-01', skip_closed_cc_categories: false });
+
+    expect(client.updateCategoryBudget).not.toHaveBeenCalled();
+    expect(result.skipped.some(s => s.category_id === 'c-save' && s.reason === 'goal_carryover')).toBe(true);
+  });
+
+  it('still sweeps a goal category with no prior carryover (pure in-month inflow)', async () => {
+    const savingsFreshInflow = createMockCategory({
+      id: 'c-save-fresh', name: 'Vacation', category_group_name: 'Savings',
+      goal_type: 'TB',
+      // prior_carryover = 20 - 0 - 20 = 0
+      budgeted: 0, activity: 20000, balance: 20000,
+    });
+    client.getBudgetMonth.mockResolvedValue(monthResponse([savingsFreshInflow]));
+
+    const result = await tool.execute({ budget_id: 'b1', month: '2024-01-01', skip_closed_cc_categories: false });
+
+    expect(client.updateCategoryBudget).toHaveBeenCalledWith('b1', 'c-save-fresh', '2024-01-01', -20000);
+    expect(result.categories_touched).toBe(1);
+  });
+
+  it('ignores zero or negative activity', async () => {
+    const quiet = createMockCategory({ id: 'c-q', name: 'Q', category_group_name: 'G', budgeted: 0, activity: 0, balance: 0 });
+    const spent = createMockCategory({ id: 'c-s', name: 'S', category_group_name: 'G', budgeted: 100000, activity: -50000, balance: 50000 });
+    client.getBudgetMonth.mockResolvedValue(monthResponse([quiet, spent]));
+
+    const result = await tool.execute({ budget_id: 'b1', month: '2024-01-01', skip_closed_cc_categories: false });
+    expect(client.updateCategoryBudget).not.toHaveBeenCalled();
+    expect(result.categories_touched).toBe(0);
+  });
+
+  it('dry_run plans without PATCHing', async () => {
+    const refund = createMockCategory({
+      id: 'c-refund', name: 'Amazon', category_group_name: 'Shopping',
+      budgeted: 0, activity: 15000, balance: 15000,
+    });
+    client.getBudgetMonth.mockResolvedValue(monthResponse([refund]));
+
+    const result = await tool.execute({ budget_id: 'b1', month: '2024-01-01', dry_run: true, skip_closed_cc_categories: false });
+
+    expect(client.updateCategoryBudget).not.toHaveBeenCalled();
+    expect(result.dry_run).toBe(true);
+    expect(result.details[0]!.status).toBe('planned');
+  });
+});

--- a/tests/tools/budgeting/categoryBudgetApplier.test.ts
+++ b/tests/tools/budgeting/categoryBudgetApplier.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { applyBudgetChanges } from '../../../src/tools/budgeting/categoryBudgetApplier.js';
+import { createMockClient, type MockYNABClient } from '../../helpers/mockClient.js';
+
+describe('applyBudgetChanges', () => {
+  let client: MockYNABClient;
+
+  beforeEach(() => {
+    client = createMockClient();
+  });
+
+  it('returns no-op summary when given empty list', async () => {
+    const res = await applyBudgetChanges(client as any, 'b1', '2024-01-01', []);
+    expect(res.applied).toBe(0);
+    expect(res.failed).toHaveLength(0);
+    expect(client.updateCategoryBudget).not.toHaveBeenCalled();
+  });
+
+  it('applies changes sequentially in input order', async () => {
+    const calls: string[] = [];
+    client.updateCategoryBudget.mockImplementation(async (_b, categoryId, _m, budgeted) => {
+      calls.push(categoryId as string);
+      return { category: { id: categoryId, budgeted } };
+    });
+
+    await applyBudgetChanges(client as any, 'b1', '2024-01-01', [
+      { category_id: 'c-1', category_name: 'A', previous_budgeted: 0, new_budgeted: 10000, delta: 10000 },
+      { category_id: 'c-2', category_name: 'B', previous_budgeted: 0, new_budgeted: 20000, delta: 20000 },
+      { category_id: 'c-3', category_name: 'C', previous_budgeted: 0, new_budgeted: 30000, delta: 30000 },
+    ]);
+
+    expect(calls).toEqual(['c-1', 'c-2', 'c-3']);
+  });
+
+  it('dry_run skips PATCHes and still returns planned changes', async () => {
+    const res = await applyBudgetChanges(
+      client as any,
+      'b1',
+      '2024-01-01',
+      [{ category_id: 'c-1', category_name: 'A', previous_budgeted: 0, new_budgeted: 10000, delta: 10000 }],
+      { dry_run: true }
+    );
+
+    expect(client.updateCategoryBudget).not.toHaveBeenCalled();
+    expect(res.applied).toBe(1);
+    expect(res.details[0]!.status).toBe('planned');
+    expect(res.total_moved_milliunits).toBe(10000);
+  });
+
+  it('records failures per category but continues the batch', async () => {
+    client.updateCategoryBudget.mockImplementation(async (_b, categoryId, _m, budgeted) => {
+      if (categoryId === 'c-boom') throw new Error('YNAB 500');
+      return { category: { id: categoryId, budgeted } };
+    });
+
+    const res = await applyBudgetChanges(client as any, 'b1', '2024-01-01', [
+      { category_id: 'c-1', category_name: 'A', previous_budgeted: 0, new_budgeted: 10000, delta: 10000 },
+      { category_id: 'c-boom', category_name: 'B', previous_budgeted: 0, new_budgeted: 20000, delta: 20000 },
+      { category_id: 'c-3', category_name: 'C', previous_budgeted: 0, new_budgeted: 30000, delta: 30000 },
+    ]);
+
+    expect(res.applied).toBe(2);
+    expect(res.failed).toHaveLength(1);
+    expect(res.failed[0]!.category_id).toBe('c-boom');
+    expect(res.failed[0]!.error).toContain('YNAB 500');
+    expect(res.details.find(d => d.category_id === 'c-boom')!.status).toBe('failed');
+  });
+
+  it('skips no-op changes (delta === 0) without hitting the API', async () => {
+    const res = await applyBudgetChanges(client as any, 'b1', '2024-01-01', [
+      { category_id: 'c-1', category_name: 'A', previous_budgeted: 5000, new_budgeted: 5000, delta: 0 },
+    ]);
+    expect(client.updateCategoryBudget).not.toHaveBeenCalled();
+    expect(res.details[0]!.status).toBe('skipped_noop');
+    expect(res.applied).toBe(0);
+  });
+
+  it('tallies total_moved_milliunits using absolute deltas', async () => {
+    const res = await applyBudgetChanges(client as any, 'b1', '2024-01-01', [
+      { category_id: 'c-1', category_name: 'A', previous_budgeted: 0, new_budgeted: 10000, delta: 10000 },
+      { category_id: 'c-2', category_name: 'B', previous_budgeted: 5000, new_budgeted: 2000, delta: -3000 },
+    ]);
+    expect(res.total_moved_milliunits).toBe(13000);
+  });
+});

--- a/tests/tools/budgeting/categoryFilters.test.ts
+++ b/tests/tools/budgeting/categoryFilters.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest';
+import {
+  filterCategories,
+  getClosedCcAccountNames,
+  CLOSED_CC_ACCOUNT_TYPES,
+} from '../../../src/tools/budgeting/categoryFilters.js';
+import { createMockCategory, createMockAccount } from '../../helpers/fixtures.js';
+
+describe('getClosedCcAccountNames', () => {
+  it('returns names of closed debt-like accounts only', () => {
+    const accounts = [
+      createMockAccount({ name: 'Open Visa', type: 'creditCard', closed: false }),
+      createMockAccount({ name: 'Closed Amex', type: 'creditCard', closed: true }),
+      createMockAccount({ name: 'Closed LoC', type: 'lineOfCredit', closed: true }),
+      createMockAccount({ name: 'Closed Checking', type: 'checking', closed: true }),
+      createMockAccount({ name: 'Closed Loan', type: 'otherDebt', closed: true }),
+    ];
+    const names = getClosedCcAccountNames(accounts);
+    expect(names).toContain('Closed Amex');
+    expect(names).toContain('Closed LoC');
+    expect(names).toContain('Closed Loan');
+    expect(names).not.toContain('Open Visa');
+    expect(names).not.toContain('Closed Checking');
+  });
+
+  it('recognises every debt-like account type', () => {
+    for (const type of CLOSED_CC_ACCOUNT_TYPES) {
+      const accts = [createMockAccount({ name: `X-${type}`, type, closed: true })];
+      expect(getClosedCcAccountNames(accts)).toEqual([`X-${type}`]);
+    }
+  });
+});
+
+describe('filterCategories', () => {
+  const cats = () => [
+    createMockCategory({ id: 'c-food', name: 'Food', category_group_name: 'Groceries' }),
+    createMockCategory({ id: 'c-hidden', name: 'Old Toys', hidden: true, category_group_name: 'Fun' }),
+    createMockCategory({ id: 'c-deleted', name: 'Gone', deleted: true, category_group_name: 'Fun' }),
+    createMockCategory({ id: 'c-rta', name: 'Inflow: Ready to Assign', category_group_name: 'Internal Master Category' }),
+    createMockCategory({ id: 'c-cc-open', name: 'Open Visa', category_group_name: 'Credit Card Payments' }),
+    createMockCategory({ id: 'c-cc-closed', name: 'Closed Amex', category_group_name: 'Credit Card Payments' }),
+  ];
+
+  it('drops Ready-to-Assign always (never fundable)', () => {
+    const { kept } = filterCategories(cats());
+    expect(kept.map(c => c.id)).not.toContain('c-rta');
+  });
+
+  it('drops hidden and deleted by default', () => {
+    const { kept } = filterCategories(cats());
+    expect(kept.map(c => c.id)).not.toContain('c-hidden');
+    expect(kept.map(c => c.id)).not.toContain('c-deleted');
+  });
+
+  it('keeps hidden when skip_hidden=false', () => {
+    const { kept } = filterCategories(cats(), { skip_hidden: false });
+    expect(kept.map(c => c.id)).toContain('c-hidden');
+  });
+
+  it('never keeps deleted (safety: always skipped)', () => {
+    const { kept } = filterCategories(cats(), { skip_deleted: false });
+    expect(kept.map(c => c.id)).not.toContain('c-deleted');
+  });
+
+  it('applies include list (by id)', () => {
+    const { kept } = filterCategories(cats(), { include: ['c-food'] });
+    expect(kept.map(c => c.id)).toEqual(['c-food']);
+  });
+
+  it('applies include list (by name, case-insensitive)', () => {
+    const { kept } = filterCategories(cats(), { include: ['food'] });
+    expect(kept.map(c => c.id)).toEqual(['c-food']);
+  });
+
+  it('applies exclude list (by id or name)', () => {
+    const { kept } = filterCategories(cats(), { exclude: ['c-food', 'open visa'] });
+    expect(kept.map(c => c.id)).not.toContain('c-food');
+    expect(kept.map(c => c.id)).not.toContain('c-cc-open');
+  });
+
+  it('drops closed-CC categories when names supplied', () => {
+    const { kept } = filterCategories(cats(), {
+      closed_cc_account_names: ['Closed Amex'],
+    });
+    expect(kept.map(c => c.id)).toContain('c-cc-open');
+    expect(kept.map(c => c.id)).not.toContain('c-cc-closed');
+  });
+
+  it('only matches closed-CC within the Credit Card Payments group (safe fail)', () => {
+    // A regular category that happens to share a name with a closed CC account
+    // should NOT be filtered out, because closed-CC matching is scoped to the
+    // CC Payments group.
+    const list = [
+      ...cats(),
+      createMockCategory({ id: 'c-namesake', name: 'Closed Amex', category_group_name: 'Groceries' }),
+    ];
+    const { kept } = filterCategories(list, { closed_cc_account_names: ['Closed Amex'] });
+    expect(kept.map(c => c.id)).toContain('c-namesake');
+    expect(kept.map(c => c.id)).not.toContain('c-cc-closed');
+  });
+
+  it('records per-skip reasons for audit', () => {
+    const { skipped } = filterCategories(cats(), { exclude: ['c-food'], closed_cc_account_names: ['Closed Amex'] });
+    const byId = Object.fromEntries(skipped.map(s => [s.category_id, s.reason]));
+    expect(byId['c-food']).toBe('excluded');
+    expect(byId['c-rta']).toBe('ready_to_assign');
+    expect(byId['c-hidden']).toBe('hidden');
+    expect(byId['c-deleted']).toBe('deleted');
+    expect(byId['c-cc-closed']).toBe('closed_cc');
+  });
+
+  describe('skip_goal_carryover (sweep-style)', () => {
+    it('skips categories with a goal AND positive prior-month carryover', () => {
+      const savings = createMockCategory({
+        id: 'c-save',
+        name: 'Vacation',
+        goal_type: 'TB',
+        // balance 150, budgeted 50, activity 0 -> prior_carryover = 100
+        budgeted: 50000,
+        activity: 0,
+        balance: 150000,
+      });
+      const { kept, skipped } = filterCategories([savings], { skip_goal_carryover: true });
+      expect(kept).toHaveLength(0);
+      expect(skipped[0]!.reason).toBe('goal_carryover');
+    });
+
+    it('sweeps a goal category with no prior carryover', () => {
+      const justBudgeted = createMockCategory({
+        id: 'c-save-fresh',
+        name: 'Vacation',
+        goal_type: 'TB',
+        // balance 50, budgeted 50, activity 0 -> prior_carryover = 0
+        budgeted: 50000,
+        activity: 0,
+        balance: 50000,
+      });
+      const { kept } = filterCategories([justBudgeted], { skip_goal_carryover: true });
+      expect(kept).toHaveLength(1);
+    });
+
+    it('sweeps a non-goal category even with prior carryover', () => {
+      const noGoal = createMockCategory({
+        id: 'c-slush',
+        name: 'Slush',
+        goal_type: null,
+        budgeted: 0,
+        activity: 0,
+        balance: 100000,
+      });
+      const { kept } = filterCategories([noGoal], { skip_goal_carryover: true });
+      expect(kept).toHaveLength(1);
+    });
+
+    it('is disabled by default (other tools keep carryover goals)', () => {
+      const savings = createMockCategory({
+        id: 'c-save',
+        name: 'Vacation',
+        goal_type: 'TB',
+        budgeted: 50000,
+        activity: 0,
+        balance: 150000,
+      });
+      const { kept } = filterCategories([savings]);
+      expect(kept).toHaveLength(1);
+    });
+  });
+
+  it('include takes precedence: categories not in include are dropped even if otherwise kept', () => {
+    const { kept, skipped } = filterCategories(cats(), { include: ['c-food'] });
+    expect(kept.map(c => c.id)).toEqual(['c-food']);
+    const otherIds = cats().filter(c => c.id !== 'c-food' && !c.deleted && !c.hidden && c.category_group_name !== 'Internal Master Category').map(c => c.id);
+    for (const id of otherIds) {
+      expect(skipped.some(s => s.category_id === id && s.reason === 'not_included')).toBe(true);
+    }
+  });
+});

--- a/tests/tools/budgeting/resetAvailableAmounts.test.ts
+++ b/tests/tools/budgeting/resetAvailableAmounts.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ResetAvailableAmountsTool } from '../../../src/tools/budgeting/resetAvailableAmounts.js';
+import { createMockClient, type MockYNABClient } from '../../helpers/mockClient.js';
+import { createMockCategory } from '../../helpers/fixtures.js';
+
+function monthResponse(categories: any[], to_be_budgeted = 0) {
+  return {
+    month: {
+      month: '2024-01-01', note: null, income: 0, budgeted: 0, activity: 0,
+      to_be_budgeted, age_of_money: null, deleted: false, categories,
+    },
+    server_knowledge: 1,
+  };
+}
+
+describe('ResetAvailableAmountsTool', () => {
+  let client: MockYNABClient;
+  let tool: ResetAvailableAmountsTool;
+
+  beforeEach(() => {
+    client = createMockClient();
+    tool = new ResetAvailableAmountsTool(client as any);
+  });
+
+  it('zeroes positive balance by reducing budgeted', async () => {
+    // balance=50, budgeted=50, activity=0 -> new_budgeted = 50 - 50 = 0
+    const c = createMockCategory({ id: 'c-1', name: 'A', category_group_name: 'G', budgeted: 50000, activity: 0, balance: 50000 });
+    client.getBudgetMonth.mockResolvedValue(monthResponse([c]));
+
+    await tool.execute({ budget_id: 'b1', month: '2024-01-01', skip_closed_cc_categories: false });
+
+    expect(client.updateCategoryBudget).toHaveBeenCalledWith('b1', 'c-1', '2024-01-01', 0);
+  });
+
+  it('zeroes negative balance by raising budgeted', async () => {
+    // balance=-20, budgeted=0, activity=-20 -> new_budgeted = 0 - (-20) = 20
+    const c = createMockCategory({ id: 'c-2', name: 'B', category_group_name: 'G', budgeted: 0, activity: -20000, balance: -20000 });
+    client.getBudgetMonth.mockResolvedValue(monthResponse([c]));
+
+    await tool.execute({ budget_id: 'b1', month: '2024-01-01', skip_closed_cc_categories: false });
+
+    expect(client.updateCategoryBudget).toHaveBeenCalledWith('b1', 'c-2', '2024-01-01', 20000);
+  });
+
+  it('skips categories already at balance=0', async () => {
+    const c = createMockCategory({ id: 'c-3', name: 'C', category_group_name: 'G', budgeted: 100000, activity: -100000, balance: 0 });
+    client.getBudgetMonth.mockResolvedValue(monthResponse([c]));
+
+    const r = await tool.execute({ budget_id: 'b1', month: '2024-01-01', skip_closed_cc_categories: false });
+    expect(client.updateCategoryBudget).not.toHaveBeenCalled();
+    expect(r.categories_touched).toBe(0);
+  });
+
+  it('reports phase name', async () => {
+    client.getBudgetMonth.mockResolvedValue(monthResponse([]));
+    const r = await tool.execute({ budget_id: 'b1', month: '2024-01-01', skip_closed_cc_categories: false });
+    expect(r.phase).toBe('reset_available_amounts');
+  });
+});


### PR DESCRIPTION
## Summary
Closes #14. Adds six new tools under `src/tools/budgeting/` that collapse 40–60 per-month category PATCHes into one MCP call each — the same pattern YNAB's web "Auto-Assign" buttons use internally.

### Tools
| Tool | Purpose |
|---|---|
| \`ynab_auto_assign_underfunded\` | Fund every category with \`balance < 0\` to exactly \$0 |
| \`ynab_auto_sweep_positives\` | Push positive activity (refunds, interest) back to RTA; preserves goal categories with positive prior-month carryover |
| \`ynab_auto_balance_month\` | sweep → assign, one call |
| \`ynab_reset_available_amounts\` | Zero every filtered category's balance for the month |
| \`ynab_assign_same_as_last_month\` | Copy prior month's budgeted per category |
| \`ynab_assign_average_spend\` | Set budgeted = rolling avg absolute outflow over \`lookback_months\` (default 3) |

### Defaults and safeties
- \`skip_closed_cc_categories: true\` — closed credit-card / debt-like accounts have their payment categories excluded automatically (per-invocation account lookup; scoped to the "Credit Card Payments" group so a namesake regular category isn't caught)
- Sweep additionally preserves categories with a savings goal **and** positive prior-month carryover (so in-flight saving isn't undone)
- \`dry_run: true\` on every tool previews without PATCHing, and skips the post-run refresh GET
- Sequential PATCHes only; the existing rate limiter paces them
- Per-category failures are captured and reporting continues (transient 500 on one category doesn't abort the batch)

### Shared plumbing
- \`categoryFilters.ts\` — include/exclude (id or name, case-insensitive), skip hidden/deleted/RTA, closed-CC, goal-carryover
- \`categoryBudgetApplier.ts\` — sequential PATCH loop with failure isolation and dry_run
- \`monthMath.ts\` — previous/prior-months helpers
- \`shared.ts\` — base input schema, context loader, post-run to_be_budgeted refresh, money formatting

### Response shape (common)
\`\`\`
{
  phase, dry_run, categories_touched, total_moved_milliunits,
  to_be_budgeted_before, to_be_budgeted_after,
  skipped: [{ category_id, category_name, reason }],
  details: [{ ..., status: 'applied' | 'planned' | 'skipped_noop' | 'failed' }],
  failed: [{ category_id, category_name, error }]
}
\`\`\`

## Test plan
- [x] Red/green TDD for each tool + helper (72 new tests, 422 passing total).
- [x] \`npm test\` — 422 passed, 2 skipped.
- [x] \`npm run lint\` clean.
- [x] Registry test covers all six new tools.
- [x] Bumped to v1.4.0.