### PR TITLE
fix(create): enrich YNAB 400 with CC+RTA hint (#12)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ynab-mcp-server",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Comprehensive Model Context Protocol server providing intelligent access to YNAB (You Need A Budget) data with AI-powered budget recommendations, spending analysis, and complete transaction management",
   "type": "module",
   "main": "dist/index.js",

--- a/src/tools/common/ccInflowValidation.ts
+++ b/src/tools/common/ccInflowValidation.ts
@@ -28,10 +28,8 @@ const DEBT_LIKE_ACCOUNT_TYPES = new Set<string>([
 const INTERNAL_MASTER_CATEGORY_GROUP = 'Internal Master Category';
 
 function isBadRequest(err: unknown): boolean {
-  return (
-    err instanceof YNABError &&
-    (err.type === 'validation' || err.statusCode === 400)
-  );
+  // ErrorHandler maps HTTP 400 to type 'validation', so the type check is sufficient.
+  return err instanceof YNABError && err.type === 'validation';
 }
 
 /** Inspect a failed create/update call and, if the underlying cause is the

--- a/src/tools/common/ccInflowValidation.ts
+++ b/src/tools/common/ccInflowValidation.ts
@@ -1,0 +1,73 @@
+import type { YNABClient } from '../../client/YNABClient.js';
+import { YNABError } from '../../client/ErrorHandler.js';
+
+/** YNAB rejects "Inflow: Ready to Assign" on credit-card-like account
+ * transactions because CC accounts have their own Credit Card Payment
+ * category model. The API's response is a generic "Bad request" with no
+ * pointer to the category. Issue #11 (payees) took the same approach for
+ * reserved names; this module does the analogue for a semantically
+ * incompatible category. */
+export const CC_INCOMPATIBLE_CATEGORY_HINT =
+  '"Inflow: Ready to Assign" is not valid for credit card accounts. ' +
+  'Use a Credit Card Payment category (in the "Credit Card Payments" group) for payments, ' +
+  'or leave category_id null for refunds/credits on a credit card.';
+
+const DEBT_LIKE_ACCOUNT_TYPES = new Set<string>([
+  'creditCard',
+  'lineOfCredit',
+  'otherDebt',
+  'mortgage',
+  'autoLoan',
+  'studentLoan',
+  'personalLoan',
+  'medicalDebt',
+]);
+
+/** YNAB's internal category group housing "Inflow: Ready to Assign" and
+ * its siblings. Matches the constant used by the budgeting tools. */
+const INTERNAL_MASTER_CATEGORY_GROUP = 'Internal Master Category';
+
+function isBadRequest(err: unknown): boolean {
+  return (
+    err instanceof YNABError &&
+    (err.type === 'validation' || err.statusCode === 400)
+  );
+}
+
+/** Inspect a failed create/update call and, if the underlying cause is the
+ * "Inflow: Ready to Assign" category being used against a credit-card
+ * account, return a replacement error with a clear hint. Otherwise return
+ * the original error unchanged.
+ *
+ * This only runs on the failure path (2 extra GETs in the worst case),
+ * so the happy path pays no overhead. */
+export async function maybeEnrichCcInflowError(
+  client: YNABClient,
+  err: unknown,
+  budgetId: string,
+  accountId: string,
+  categoryId: string | null | undefined
+): Promise<Error> {
+  const original = err instanceof Error ? err : new Error(String(err));
+  if (!categoryId) return original;
+  if (!isBadRequest(err)) return original;
+
+  try {
+    const [account, categoryResponse] = await Promise.all([
+      client.getAccount(budgetId, accountId),
+      client.getCategory(budgetId, categoryId),
+    ]);
+    const accountType = account?.type ?? '';
+    const groupName = categoryResponse?.category?.category_group_name ?? '';
+    if (
+      DEBT_LIKE_ACCOUNT_TYPES.has(accountType) &&
+      groupName === INTERNAL_MASTER_CATEGORY_GROUP
+    ) {
+      return new Error(CC_INCOMPATIBLE_CATEGORY_HINT);
+    }
+  } catch {
+    // Enrichment failed (offline, rate-limited, etc.) — fall through
+    // to the original error rather than masking it.
+  }
+  return original;
+}

--- a/src/tools/transactions/createSplitTransaction.ts
+++ b/src/tools/transactions/createSplitTransaction.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { YnabTool } from '../base.js';
 import { assertPayeeNameAllowed } from '../common/reservedPayees.js';
+import { maybeEnrichCcInflowError } from '../common/ccInflowValidation.js';
 import type { YnabTransactionsResponse, YnabPayeesResponse, SaveTransaction } from '../../types/index.js';
 
 /**
@@ -253,11 +254,21 @@ export class CreateSplitTransactionTool extends YnabTool {
         subtransactions: processedSubtransactions,
       };
 
-      // Create the split transaction
-      const response: YnabTransactionsResponse = await this.client.createTransactions(
-        input.budget_id,
-        [transactionData]
-      );
+      // Check the first non-null subtransaction category for RTA-on-CC
+      // enrichment (#12). Splits have no parent category_id.
+      const firstCategoryId = processedSubtransactions.find(s => s.category_id)?.category_id ?? null;
+      let response: YnabTransactionsResponse;
+      try {
+        response = await this.client.createTransactions(input.budget_id, [transactionData]);
+      } catch (createError) {
+        throw await maybeEnrichCcInflowError(
+          this.client,
+          createError,
+          input.budget_id,
+          input.account_id,
+          firstCategoryId
+        );
+      }
 
       if (!response.transactions || response.transactions.length === 0) {
         throw new Error('No transaction returned from YNAB API');

--- a/src/tools/transactions/createSplitTransaction.ts
+++ b/src/tools/transactions/createSplitTransaction.ts
@@ -254,20 +254,31 @@ export class CreateSplitTransactionTool extends YnabTool {
         subtransactions: processedSubtransactions,
       };
 
-      // Check the first non-null subtransaction category for RTA-on-CC
-      // enrichment (#12). Splits have no parent category_id.
-      const firstCategoryId = processedSubtransactions.find(s => s.category_id)?.category_id ?? null;
+      // Create. On a YNAB 400, probe EVERY non-null subtransaction category
+      // for RTA-on-CC enrichment (#12) — the offending subtxn could be at
+      // any position. Splits have no parent category_id.
       let response: YnabTransactionsResponse;
       try {
         response = await this.client.createTransactions(input.budget_id, [transactionData]);
       } catch (createError) {
-        throw await maybeEnrichCcInflowError(
-          this.client,
-          createError,
-          input.budget_id,
-          input.account_id,
-          firstCategoryId
-        );
+        const subCategoryIds = processedSubtransactions
+          .map(s => s.category_id)
+          .filter((v): v is string => !!v);
+        let enriched: Error = createError instanceof Error ? createError : new Error(String(createError));
+        for (const categoryId of subCategoryIds) {
+          const candidate = await maybeEnrichCcInflowError(
+            this.client,
+            createError,
+            input.budget_id,
+            input.account_id,
+            categoryId
+          );
+          if (candidate !== createError) {
+            enriched = candidate;
+            break;
+          }
+        }
+        throw enriched;
       }
 
       if (!response.transactions || response.transactions.length === 0) {

--- a/src/tools/transactions/createTransaction.ts
+++ b/src/tools/transactions/createTransaction.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { YnabTool } from '../base.js';
 import { assertPayeeNameAllowed } from '../common/reservedPayees.js';
+import { maybeEnrichCcInflowError } from '../common/ccInflowValidation.js';
 import type { YnabTransactionsResponse, YnabPayeesResponse } from '../../types/index.js';
 
 /**
@@ -134,11 +135,21 @@ export class CreateTransactionTool extends YnabTool {
         import_id: input.import_id || null,
       };
 
-      // Create the transaction
-      const response: YnabTransactionsResponse = await this.client.createTransactions(
-        input.budget_id,
-        [transactionData]
-      );
+      // Create the transaction. On a generic YNAB 400 we try to enrich the
+      // error with the specific RTA-on-CC hint (issue #12) before letting
+      // it bubble to handleError.
+      let response: YnabTransactionsResponse;
+      try {
+        response = await this.client.createTransactions(input.budget_id, [transactionData]);
+      } catch (createError) {
+        throw await maybeEnrichCcInflowError(
+          this.client,
+          createError,
+          input.budget_id,
+          input.account_id,
+          input.category_id ?? null
+        );
+      }
 
       if (!response.transactions || response.transactions.length === 0) {
         throw new Error('No transaction returned from YNAB API');

--- a/src/tools/transactions/updateTransaction.ts
+++ b/src/tools/transactions/updateTransaction.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { YnabTool } from '../base.js';
 import { assertPayeeNameAllowed } from '../common/reservedPayees.js';
+import { maybeEnrichCcInflowError } from '../common/ccInflowValidation.js';
 import type { YnabTransactionsResponse, YnabPayeesResponse, UpdateTransactionWithId } from '../../types/index.js';
 
 /**
@@ -193,11 +194,27 @@ export class UpdateTransactionTool extends YnabTool {
         throw new Error('No fields provided to update. At least one field besides transaction_id must be specified.');
       }
 
-      // Update the transaction
-      const response: YnabTransactionsResponse = await this.client.updateTransactions(
-        input.budget_id,
-        [updateData]
-      );
+      // Update the transaction. On a YNAB 400 we try to enrich the error with
+      // the specific RTA-on-CC hint (#12) before letting it bubble.
+      let response: YnabTransactionsResponse;
+      try {
+        response = await this.client.updateTransactions(input.budget_id, [updateData]);
+      } catch (updateError) {
+        if (input.category_id) {
+          const accountId =
+            input.account_id ?? (await this.client.getTransaction(input.budget_id, input.transaction_id))?.account_id;
+          if (accountId) {
+            throw await maybeEnrichCcInflowError(
+              this.client,
+              updateError,
+              input.budget_id,
+              accountId,
+              input.category_id
+            );
+          }
+        }
+        throw updateError;
+      }
 
       if (!response.transactions || response.transactions.length === 0) {
         throw new Error('No transaction returned from YNAB API after update');

--- a/src/tools/transactions/updateTransaction.ts
+++ b/src/tools/transactions/updateTransaction.ts
@@ -201,8 +201,17 @@ export class UpdateTransactionTool extends YnabTool {
         response = await this.client.updateTransactions(input.budget_id, [updateData]);
       } catch (updateError) {
         if (input.category_id) {
-          const accountId =
-            input.account_id ?? (await this.client.getTransaction(input.budget_id, input.transaction_id))?.account_id;
+          // Resolve account_id lazily when the caller didn't supply one.
+          // Wrap in its own try/catch so a failing lookup doesn't replace
+          // the original 400 with a misleading "get transaction failed".
+          let accountId: string | undefined = input.account_id;
+          if (!accountId) {
+            try {
+              accountId = (await this.client.getTransaction(input.budget_id, input.transaction_id))?.account_id;
+            } catch {
+              accountId = undefined;
+            }
+          }
           if (accountId) {
             throw await maybeEnrichCcInflowError(
               this.client,

--- a/tests/tools/common/ccInflowValidation.test.ts
+++ b/tests/tools/common/ccInflowValidation.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  maybeEnrichCcInflowError,
+  CC_INCOMPATIBLE_CATEGORY_HINT,
+} from '../../../src/tools/common/ccInflowValidation.js';
+import { YNABError } from '../../../src/client/ErrorHandler.js';
+import { createMockClient, type MockYNABClient } from '../../helpers/mockClient.js';
+import { createMockAccount, createMockCategory } from '../../helpers/fixtures.js';
+
+describe('maybeEnrichCcInflowError', () => {
+  let client: MockYNABClient;
+
+  beforeEach(() => {
+    client = createMockClient();
+  });
+
+  function badRequest(): YNABError {
+    return new YNABError({ type: 'validation', message: 'Bad request', statusCode: 400 });
+  }
+
+  it('passes through when no category_id was submitted', async () => {
+    const original = badRequest();
+    const out = await maybeEnrichCcInflowError(client as any, original, 'b1', 'a-cc', null);
+    expect(out).toBe(original);
+    expect(client.getAccount).not.toHaveBeenCalled();
+  });
+
+  it('passes through when error is not a 400/validation', async () => {
+    const other = new YNABError({ type: 'rate_limit', message: '429', statusCode: 429 });
+    const out = await maybeEnrichCcInflowError(client as any, other, 'b1', 'a-cc', 'cat-rta');
+    expect(out).toBe(other);
+    expect(client.getAccount).not.toHaveBeenCalled();
+  });
+
+  it('enriches when account is credit card AND category is in Internal Master Category group', async () => {
+    client.getAccount.mockResolvedValue(createMockAccount({ id: 'a-cc', type: 'creditCard', closed: false }));
+    client.getCategory.mockResolvedValue({
+      category: createMockCategory({ id: 'cat-rta', name: 'Inflow: Ready to Assign', category_group_name: 'Internal Master Category' }),
+      server_knowledge: 1,
+    });
+
+    const out = await maybeEnrichCcInflowError(client as any, badRequest(), 'b1', 'a-cc', 'cat-rta');
+    expect(out.message).toBe(CC_INCOMPATIBLE_CATEGORY_HINT);
+  });
+
+  it('does not enrich when account is not debt-like', async () => {
+    client.getAccount.mockResolvedValue(createMockAccount({ id: 'a-chk', type: 'checking', closed: false }));
+    client.getCategory.mockResolvedValue({
+      category: createMockCategory({ id: 'cat-rta', name: 'Inflow: Ready to Assign', category_group_name: 'Internal Master Category' }),
+      server_knowledge: 1,
+    });
+
+    const original = badRequest();
+    const out = await maybeEnrichCcInflowError(client as any, original, 'b1', 'a-chk', 'cat-rta');
+    expect(out).toBe(original);
+  });
+
+  it('does not enrich when category is not the RTA/internal one', async () => {
+    client.getAccount.mockResolvedValue(createMockAccount({ id: 'a-cc', type: 'creditCard', closed: false }));
+    client.getCategory.mockResolvedValue({
+      category: createMockCategory({ id: 'cat-food', name: 'Food', category_group_name: 'Spending' }),
+      server_knowledge: 1,
+    });
+
+    const original = badRequest();
+    const out = await maybeEnrichCcInflowError(client as any, original, 'b1', 'a-cc', 'cat-food');
+    expect(out).toBe(original);
+  });
+
+  it('returns the original error if enrichment lookups themselves fail', async () => {
+    client.getAccount.mockRejectedValue(new Error('network'));
+    const original = badRequest();
+    const out = await maybeEnrichCcInflowError(client as any, original, 'b1', 'a-cc', 'cat-rta');
+    expect(out).toBe(original);
+  });
+
+  it.each([
+    'creditCard',
+    'lineOfCredit',
+    'otherDebt',
+    'mortgage',
+    'autoLoan',
+    'studentLoan',
+    'personalLoan',
+    'medicalDebt',
+  ])('treats %s as a debt-like account for enrichment', async (type) => {
+    client.getAccount.mockResolvedValue(createMockAccount({ id: 'a', type, closed: false }));
+    client.getCategory.mockResolvedValue({
+      category: createMockCategory({ id: 'c', name: 'Inflow: Ready to Assign', category_group_name: 'Internal Master Category' }),
+      server_knowledge: 1,
+    });
+    const out = await maybeEnrichCcInflowError(client as any, badRequest(), 'b1', 'a', 'c');
+    expect(out.message).toBe(CC_INCOMPATIBLE_CATEGORY_HINT);
+  });
+});

--- a/tests/tools/transactions/createSplitTransaction.test.ts
+++ b/tests/tools/transactions/createSplitTransaction.test.ts
@@ -63,4 +63,28 @@ describe('CreateSplitTransactionTool', () => {
       ],
     })).rejects.toThrow(/Inflow: Ready to Assign.*credit card/i);
   });
+
+  it('enriches when ONLY a later subtransaction targets RTA (#12: probe all subs)', async () => {
+    client.createTransactions.mockRejectedValue(
+      new YNABError({ type: 'validation', message: 'Bad request', statusCode: 400 })
+    );
+    client.getAccount.mockResolvedValue(createMockAccount({ id: 'cc-1', type: 'creditCard', closed: false }));
+    client.getCategory.mockImplementation(async (_b, id) => {
+      if (id === 'cat-rta') {
+        return { category: createMockCategory({ id: 'cat-rta', name: 'Inflow: Ready to Assign', category_group_name: 'Internal Master Category' }), server_knowledge: 1 };
+      }
+      return { category: createMockCategory({ id, name: 'Food', category_group_name: 'Spending' }), server_knowledge: 1 };
+    });
+
+    await expect(tool.execute({
+      budget_id: 'b1',
+      account_id: 'cc-1',
+      amount: -10000,
+      date: '2024-01-15',
+      subtransactions: [
+        { amount: -5000, category_id: 'cat-food' },
+        { amount: -5000, category_id: 'cat-rta' },
+      ],
+    })).rejects.toThrow(/Inflow: Ready to Assign.*credit card/i);
+  });
 });

--- a/tests/tools/transactions/createSplitTransaction.test.ts
+++ b/tests/tools/transactions/createSplitTransaction.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { CreateSplitTransactionTool } from '../../../src/tools/transactions/createSplitTransaction.js';
+import { YNABError } from '../../../src/client/ErrorHandler.js';
 import { createMockClient, type MockYNABClient } from '../../helpers/mockClient.js';
+import { createMockAccount, createMockCategory } from '../../helpers/fixtures.js';
 
 describe('CreateSplitTransactionTool', () => {
   let client: MockYNABClient;
@@ -38,5 +40,27 @@ describe('CreateSplitTransactionTool', () => {
       ],
     })).rejects.toThrow(/reserved by YNAB/i);
     expect(client.createTransactions).not.toHaveBeenCalled();
+  });
+
+  it('enriches 400 with CC+RTA hint when a subtransaction targets RTA on a CC (#12)', async () => {
+    client.createTransactions.mockRejectedValue(
+      new YNABError({ type: 'validation', message: 'Bad request', statusCode: 400 })
+    );
+    client.getAccount.mockResolvedValue(createMockAccount({ id: 'cc-1', type: 'creditCard', closed: false }));
+    client.getCategory.mockResolvedValue({
+      category: createMockCategory({ id: 'cat-rta', name: 'Inflow: Ready to Assign', category_group_name: 'Internal Master Category' }),
+      server_knowledge: 1,
+    });
+
+    await expect(tool.execute({
+      budget_id: 'b1',
+      account_id: 'cc-1',
+      amount: -10000,
+      date: '2024-01-15',
+      subtransactions: [
+        { amount: -5000, category_id: 'cat-rta' },
+        { amount: -5000, category_id: 'cat-food' },
+      ],
+    })).rejects.toThrow(/Inflow: Ready to Assign.*credit card/i);
   });
 });

--- a/tests/tools/transactions/createTransaction.test.ts
+++ b/tests/tools/transactions/createTransaction.test.ts
@@ -4,8 +4,9 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { CreateTransactionTool } from '../../../src/tools/transactions/createTransaction.js';
+import { YNABError } from '../../../src/client/ErrorHandler.js';
 import { createMockClient, type MockYNABClient } from '../../helpers/mockClient.js';
-import { createMockTransaction, createMockPayee } from '../../helpers/fixtures.js';
+import { createMockTransaction, createMockPayee, createMockAccount, createMockCategory } from '../../helpers/fixtures.js';
 
 describe('CreateTransactionTool', () => {
   let client: MockYNABClient;
@@ -269,6 +270,44 @@ describe('CreateTransactionTool', () => {
         amount: -50000,
         date: '2024-01-15',
       })).rejects.toThrow('No transaction returned');
+    });
+
+    it('enriches 400 with a CC+RTA hint (issue #12)', async () => {
+      client.createTransactions.mockRejectedValue(
+        new YNABError({ type: 'validation', message: 'Bad request', statusCode: 400 })
+      );
+      client.getAccount.mockResolvedValue(createMockAccount({ id: 'cc-1', type: 'creditCard', closed: false }));
+      client.getCategory.mockResolvedValue({
+        category: createMockCategory({ id: 'cat-rta', name: 'Inflow: Ready to Assign', category_group_name: 'Internal Master Category' }),
+        server_knowledge: 1,
+      });
+
+      await expect(tool.execute({
+        budget_id: 'b1',
+        account_id: 'cc-1',
+        category_id: 'cat-rta',
+        amount: 10000,
+        date: '2024-01-01',
+      })).rejects.toThrow(/Inflow: Ready to Assign.*credit card/i);
+    });
+
+    it('does not enrich when account is not debt-like (#12 safety)', async () => {
+      client.createTransactions.mockRejectedValue(
+        new YNABError({ type: 'validation', message: 'Bad request', statusCode: 400 })
+      );
+      client.getAccount.mockResolvedValue(createMockAccount({ id: 'chk-1', type: 'checking', closed: false }));
+      client.getCategory.mockResolvedValue({
+        category: createMockCategory({ id: 'cat-rta', name: 'Inflow: Ready to Assign', category_group_name: 'Internal Master Category' }),
+        server_knowledge: 1,
+      });
+
+      await expect(tool.execute({
+        budget_id: 'b1',
+        account_id: 'chk-1',
+        category_id: 'cat-rta',
+        amount: 10000,
+        date: '2024-01-01',
+      })).rejects.toThrow(/Bad request/);
     });
   });
 });

--- a/tests/tools/transactions/updateTransaction.test.ts
+++ b/tests/tools/transactions/updateTransaction.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { UpdateTransactionTool } from '../../../src/tools/transactions/updateTransaction.js';
+import { YNABError } from '../../../src/client/ErrorHandler.js';
 import { createMockClient, type MockYNABClient } from '../../helpers/mockClient.js';
+import { createMockAccount, createMockCategory, createMockTransaction } from '../../helpers/fixtures.js';
 
 describe('UpdateTransactionTool', () => {
   let client: MockYNABClient;
@@ -18,5 +20,41 @@ describe('UpdateTransactionTool', () => {
       payee_name: 'Starting Balance',
     })).rejects.toThrow(/reserved by YNAB/i);
     expect(client.updateTransaction).not.toHaveBeenCalled();
+  });
+
+  it('enriches 400 with CC+RTA hint when input.account_id is supplied (#12)', async () => {
+    client.updateTransactions.mockRejectedValue(
+      new YNABError({ type: 'validation', message: 'Bad request', statusCode: 400 })
+    );
+    client.getAccount.mockResolvedValue(createMockAccount({ id: 'cc-1', type: 'creditCard', closed: false }));
+    client.getCategory.mockResolvedValue({
+      category: createMockCategory({ id: 'cat-rta', name: 'Inflow: Ready to Assign', category_group_name: 'Internal Master Category' }),
+      server_knowledge: 1,
+    });
+
+    await expect(tool.execute({
+      budget_id: 'b1',
+      transaction_id: 'tx-1',
+      account_id: 'cc-1',
+      category_id: 'cat-rta',
+    })).rejects.toThrow(/Inflow: Ready to Assign.*credit card/i);
+  });
+
+  it('falls back to fetching the transaction to resolve account_id for enrichment (#12)', async () => {
+    client.updateTransactions.mockRejectedValue(
+      new YNABError({ type: 'validation', message: 'Bad request', statusCode: 400 })
+    );
+    client.getTransaction.mockResolvedValue(createMockTransaction({ id: 'tx-1', account_id: 'cc-1' }));
+    client.getAccount.mockResolvedValue(createMockAccount({ id: 'cc-1', type: 'creditCard', closed: false }));
+    client.getCategory.mockResolvedValue({
+      category: createMockCategory({ id: 'cat-rta', name: 'Inflow: Ready to Assign', category_group_name: 'Internal Master Category' }),
+      server_knowledge: 1,
+    });
+
+    await expect(tool.execute({
+      budget_id: 'b1',
+      transaction_id: 'tx-1',
+      category_id: 'cat-rta',
+    })).rejects.toThrow(/Inflow: Ready to Assign.*credit card/i);
   });
 });

--- a/tests/tools/transactions/updateTransaction.test.ts
+++ b/tests/tools/transactions/updateTransaction.test.ts
@@ -57,4 +57,17 @@ describe('UpdateTransactionTool', () => {
       category_id: 'cat-rta',
     })).rejects.toThrow(/Inflow: Ready to Assign.*credit card/i);
   });
+
+  it('preserves the original 400 when the account_id lookup itself fails (#12 safety)', async () => {
+    client.updateTransactions.mockRejectedValue(
+      new YNABError({ type: 'validation', message: 'Bad request', statusCode: 400 })
+    );
+    client.getTransaction.mockRejectedValue(new Error('transaction not found'));
+
+    await expect(tool.execute({
+      budget_id: 'b1',
+      transaction_id: 'tx-missing',
+      category_id: 'cat-rta',
+    })).rejects.toThrow(/Bad request/);
+  });
 });


### PR DESCRIPTION
## Summary
- Closes #12
- \"Inflow: Ready to Assign\" on a credit-card transaction is a semantic mismatch in YNAB's data model. The API rejects it with a terse \"Bad request\" and no pointer to the category being the cause.
- On a 400/validation error from \`createTransactions\`, when \`category_id\` was supplied, fetch the account and the category in parallel and — if the account is debt-like *and* the category belongs to the Internal Master Category group — replace the error with an explicit hint naming the constraint and the valid alternatives.
- Zero overhead on the happy path (enrichment only runs on failure). Enrichment itself is best-effort: if the lookups throw, we fall back to the original error.

## Test plan
- [x] 14 red/green tests on the shared helper (\`tests/tools/common/ccInflowValidation.test.ts\`) covering: no category_id, non-400 errors, all 8 debt-like account types, non-debt accounts, non-RTA categories, lookup failures.
- [x] End-to-end tests on \`ynab_create_transaction\`: enriches CC + RTA, does not enrich checking + RTA.
- [x] \`npm test\` — 441 passed, 2 skipped.
- [x] \`npm run lint\` clean.
- [x] Bumped to v1.4.1.