### PR TITLE
feat: ynab_batch_create_transactions (#13)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ynab-mcp-server",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Comprehensive Model Context Protocol server providing intelligent access to YNAB (You Need A Budget) data with AI-powered budget recommendations, spending analysis, and complete transaction management",
   "type": "module",
   "main": "dist/index.js",

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -12,6 +12,7 @@ import { CreateTransactionTool } from './transactions/createTransaction.js';
 import { UpdateTransactionTool } from './transactions/updateTransaction.js';
 import { DeleteTransactionTool } from './transactions/deleteTransaction.js';
 import { BatchUpdateTransactionsTool } from './transactions/batchUpdateTransactions.js';
+import { BatchCreateTransactionsTool } from './transactions/batchCreateTransactions.js';
 import { CreateSplitTransactionTool } from './transactions/createSplitTransaction.js';
 import { UpdateTransactionSplitsTool } from './transactions/updateTransactionSplits.js';
 import { ExportTransactionsTool } from './transactions/exportTransactions.js';
@@ -65,6 +66,7 @@ export function registerTools(client: YNABClient): Tool[] {
     new UpdateTransactionTool(client),
     new DeleteTransactionTool(client),
     new BatchUpdateTransactionsTool(client),
+    new BatchCreateTransactionsTool(client),
     new CreateSplitTransactionTool(client),
     new UpdateTransactionSplitsTool(client),
     new ExportTransactionsTool(client),

--- a/src/tools/transactions/batchCreateTransactions.ts
+++ b/src/tools/transactions/batchCreateTransactions.ts
@@ -4,22 +4,20 @@ import { assertPayeeNameAllowed } from '../common/reservedPayees.js';
 import { YNABError } from '../../client/ErrorHandler.js';
 import type { SaveTransaction, YnabTransaction, YnabTransactionsResponse } from '../../types/index.js';
 
-/** Input shape for one transaction in a batch create. Mirrors
- * CreateTransactionTool's schema but makes `import_id` optional and
- * defaults `approved` to true (deliberate user-initiated creates, not
- * feed imports). */
+// One transaction in a batch-create payload. Mirrors create_transaction but
+// makes import_id optional and defaults approved=true (user-initiated).
 const BatchCreateTransactionInputSchema = z.object({
   account_id: z.string().describe('The account ID where the transaction will be created'),
   category_id: z.string().nullable().optional().describe('The category ID for the transaction. Use null for transfers or income'),
   payee_id: z.string().nullable().optional().describe('The payee ID for the transaction'),
-  payee_name: z.string().optional().describe('The payee name. Tool does NOT auto-create payees in batch mode to avoid extra API calls; set payee_id or an exact existing name'),
+  payee_name: z.string().optional().describe('The payee name. Tool does NOT auto-create payees in batch mode; set payee_id or an exact existing name'),
   amount: z.number().int().describe('Transaction amount in milliunits. Negative for outflows, positive for inflows'),
   memo: z.string().optional().describe('Optional memo/description for the transaction'),
   date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).describe('Transaction date in YYYY-MM-DD format'),
-  cleared: z.enum(['cleared', 'uncleared', 'reconciled']).optional().default('uncleared').describe('Cleared status. Unlike import_transactions, this tool defaults approved=true so reconciled is preserved without special handling'),
+  cleared: z.enum(['cleared', 'uncleared', 'reconciled']).optional().default('uncleared').describe('Cleared status. This tool defaults approved=true so reconciled is preserved without special handling'),
   approved: z.boolean().optional().default(true).describe('Whether the transaction is approved. Default true'),
   flag_color: z.enum(['red', 'orange', 'yellow', 'green', 'blue', 'purple']).nullable().optional().describe('Flag color for the transaction'),
-  import_id: z.string().max(36, 'Import ID must be 36 characters or less (YNAB API limit)').optional().describe('Optional deduplication key. Max 36 characters'),
+  import_id: z.string().max(36, 'Import ID must be 36 characters or less (YNAB API limit)').optional().describe('Optional deduplication key. Max 36 characters. Supplying one also lets the response correlate created rows back to submission order'),
 });
 
 type BatchCreateTransactionInput = z.infer<typeof BatchCreateTransactionInputSchema>;
@@ -33,7 +31,8 @@ type BatchCreateInput = z.infer<typeof BatchCreateInputSchema>;
 
 interface CreatedTransactionSummary {
   id: string;
-  index: number;
+  // Submission index when correlate-able (import_id present or per-row fallback), else null. In bulk mode without import_ids YNAB does not guarantee response order matches submission order.
+  index: number | null;
   date: string;
   amount: { milliunits: number; formatted: string };
   account_id: string;
@@ -53,7 +52,8 @@ export interface BatchCreateResult {
   created: CreatedTransactionSummary[];
   failed: FailedTransaction[];
   duplicate_import_ids: string[];
-  server_knowledge: number;
+  // null when no successful API call was made (e.g. every fallback row failed). Avoids callers confusing 0 with "no prior knowledge" for delta sync.
+  server_knowledge: number | null;
   summary: {
     total_submitted: number;
     created: number;
@@ -84,7 +84,7 @@ function formatCurrency(milliunits: number): string {
   return dollars < 0 ? `-$${Math.abs(dollars).toFixed(2)}` : `$${dollars.toFixed(2)}`;
 }
 
-function summarize(tx: YnabTransaction, index: number): CreatedTransactionSummary {
+function summarize(tx: YnabTransaction, index: number | null): CreatedTransactionSummary {
   return {
     id: tx.id,
     index,
@@ -98,20 +98,17 @@ function summarize(tx: YnabTransaction, index: number): CreatedTransactionSummar
   };
 }
 
-function isClientError(err: unknown): boolean {
+// Only YNAB 400 and 409 (conflict) hint at "a specific row is bad." Auth
+// (401/403), rate-limit (429), 5xx, and network errors are system-level
+// problems where per-row fallback would just amplify the damage.
+function shouldFallbackOn(err: unknown): boolean {
   if (!(err instanceof YNABError)) return false;
-  return err.statusCode !== undefined && err.statusCode >= 400 && err.statusCode < 500;
+  return err.statusCode === 400 || err.statusCode === 409;
 }
 
-/** Create many transactions in one call. Attempts a single bulk POST for
- * the happy path; on a YNAB 4xx response (which by design aborts the whole
- * batch and hides which row was at fault), falls back to per-row POSTs so
- * the caller gets index-aligned success/failure detail. Non-4xx failures
- * (rate-limit, 5xx, network) surface as a tool-level error rather than
- * amplifying into per-row retries. */
 export class BatchCreateTransactionsTool extends YnabTool {
   name = 'ynab_batch_create_transactions';
-  description = 'Create up to 100 transactions in a single batch. Tries one bulk POST; on YNAB validation (4xx) failures, falls back to per-transaction POSTs and reports which rows succeeded and which failed. Preserves cleared=reconciled with approved=true defaults. Amounts in milliunits.';
+  description = 'Create up to 100 transactions in a single batch. Tries one bulk POST; on a YNAB 400/409 (which by design aborts the whole batch and hides which row was at fault), automatically falls back to per-transaction POSTs and reports which rows succeeded and which failed. Preserves cleared=reconciled with approved=true defaults. Amounts in milliunits.';
   inputSchema = BatchCreateInputSchema;
 
   async execute(args: unknown): Promise<BatchCreateResult> {
@@ -121,11 +118,15 @@ export class BatchCreateTransactionsTool extends YnabTool {
     }
 
     try {
-      return await this.bulkCreate(input);
-    } catch (error) {
-      if (isClientError(error) && input.transactions.length > 1) {
+      try {
+        return await this.bulkCreate(input);
+      } catch (bulkError) {
+        if (!shouldFallbackOn(bulkError) || input.transactions.length <= 1) {
+          throw bulkError;
+        }
         return await this.fallbackPerTransaction(input);
       }
+    } catch (error) {
       this.handleError(error, 'batch create transactions');
     }
   }
@@ -134,7 +135,18 @@ export class BatchCreateTransactionsTool extends YnabTool {
     const payload = input.transactions.map(toSaveTransaction);
     const response: YnabTransactionsResponse = await this.client.createTransactions(input.budget_id, payload);
 
-    const created = response.transactions.map((tx, i) => summarize(tx, i));
+    // Correlate created rows back to submission order via import_id when
+    // supplied. Without it, YNAB response order is not guaranteed to match
+    // submission order, so we record index=null for those rows.
+    const submissionIndexByImportId = new Map<string, number>();
+    input.transactions.forEach((t, i) => {
+      if (t.import_id) submissionIndexByImportId.set(t.import_id, i);
+    });
+    const created = response.transactions.map(tx => {
+      const index = tx.import_id ? submissionIndexByImportId.get(tx.import_id) ?? null : null;
+      return summarize(tx, index);
+    });
+
     const returnedImportIds = new Set(response.transactions.map(t => t.import_id).filter((v): v is string => !!v));
     const submittedImportIds = input.transactions.map(t => t.import_id).filter((v): v is string => !!v);
     const duplicateImportIds = submittedImportIds.filter(id => !returnedImportIds.has(id));
@@ -158,7 +170,7 @@ export class BatchCreateTransactionsTool extends YnabTool {
     const created: CreatedTransactionSummary[] = [];
     const failed: FailedTransaction[] = [];
     const duplicateImportIds: string[] = [];
-    let serverKnowledge = 0;
+    let serverKnowledge: number | null = null;
 
     for (let index = 0; index < input.transactions.length; index += 1) {
       const row = input.transactions[index]!;
@@ -178,6 +190,10 @@ export class BatchCreateTransactionsTool extends YnabTool {
         created.push(summarize(resp.transactions[0]!, index));
         serverKnowledge = resp.server_knowledge;
       } catch (error) {
+        // Only client-level 400/409 belong per-row; re-raise anything else
+        // (rate-limit, 5xx, network) instead of silently marking 100 rows
+        // as failed while the server is down.
+        if (!shouldFallbackOn(error)) throw error;
         const message = error instanceof Error ? error.message : String(error);
         failed.push({
           index,

--- a/src/tools/transactions/batchCreateTransactions.ts
+++ b/src/tools/transactions/batchCreateTransactions.ts
@@ -1,0 +1,204 @@
+import { z } from 'zod';
+import { YnabTool } from '../base.js';
+import { assertPayeeNameAllowed } from '../common/reservedPayees.js';
+import { YNABError } from '../../client/ErrorHandler.js';
+import type { SaveTransaction, YnabTransaction, YnabTransactionsResponse } from '../../types/index.js';
+
+/** Input shape for one transaction in a batch create. Mirrors
+ * CreateTransactionTool's schema but makes `import_id` optional and
+ * defaults `approved` to true (deliberate user-initiated creates, not
+ * feed imports). */
+const BatchCreateTransactionInputSchema = z.object({
+  account_id: z.string().describe('The account ID where the transaction will be created'),
+  category_id: z.string().nullable().optional().describe('The category ID for the transaction. Use null for transfers or income'),
+  payee_id: z.string().nullable().optional().describe('The payee ID for the transaction'),
+  payee_name: z.string().optional().describe('The payee name. Tool does NOT auto-create payees in batch mode to avoid extra API calls; set payee_id or an exact existing name'),
+  amount: z.number().int().describe('Transaction amount in milliunits. Negative for outflows, positive for inflows'),
+  memo: z.string().optional().describe('Optional memo/description for the transaction'),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).describe('Transaction date in YYYY-MM-DD format'),
+  cleared: z.enum(['cleared', 'uncleared', 'reconciled']).optional().default('uncleared').describe('Cleared status. Unlike import_transactions, this tool defaults approved=true so reconciled is preserved without special handling'),
+  approved: z.boolean().optional().default(true).describe('Whether the transaction is approved. Default true'),
+  flag_color: z.enum(['red', 'orange', 'yellow', 'green', 'blue', 'purple']).nullable().optional().describe('Flag color for the transaction'),
+  import_id: z.string().max(36, 'Import ID must be 36 characters or less (YNAB API limit)').optional().describe('Optional deduplication key. Max 36 characters'),
+});
+
+type BatchCreateTransactionInput = z.infer<typeof BatchCreateTransactionInputSchema>;
+
+const BatchCreateInputSchema = z.object({
+  budget_id: z.string().describe('The ID of the budget to create the transactions in'),
+  transactions: z.array(BatchCreateTransactionInputSchema).min(1).max(100).describe('Array of transactions to create (max 100 per batch)'),
+});
+
+type BatchCreateInput = z.infer<typeof BatchCreateInputSchema>;
+
+interface CreatedTransactionSummary {
+  id: string;
+  index: number;
+  date: string;
+  amount: { milliunits: number; formatted: string };
+  account_id: string;
+  category_id: string | null;
+  cleared: string;
+  approved: boolean;
+  import_id: string | null;
+}
+
+interface FailedTransaction {
+  index: number;
+  error: string;
+  input_summary: { account_id: string; amount: number; date: string };
+}
+
+export interface BatchCreateResult {
+  created: CreatedTransactionSummary[];
+  failed: FailedTransaction[];
+  duplicate_import_ids: string[];
+  server_knowledge: number;
+  summary: {
+    total_submitted: number;
+    created: number;
+    failed: number;
+    duplicates: number;
+    used_fallback: boolean;
+  };
+}
+
+function toSaveTransaction(input: BatchCreateTransactionInput): SaveTransaction {
+  return {
+    account_id: input.account_id,
+    category_id: input.category_id ?? null,
+    payee_id: input.payee_id ?? null,
+    payee_name: input.payee_name ?? null,
+    amount: input.amount,
+    memo: input.memo ?? null,
+    date: input.date,
+    cleared: input.cleared,
+    approved: input.approved,
+    flag_color: input.flag_color ?? null,
+    import_id: input.import_id ?? null,
+  };
+}
+
+function formatCurrency(milliunits: number): string {
+  const dollars = milliunits / 1000;
+  return dollars < 0 ? `-$${Math.abs(dollars).toFixed(2)}` : `$${dollars.toFixed(2)}`;
+}
+
+function summarize(tx: YnabTransaction, index: number): CreatedTransactionSummary {
+  return {
+    id: tx.id,
+    index,
+    date: tx.date,
+    amount: { milliunits: tx.amount, formatted: formatCurrency(tx.amount) },
+    account_id: tx.account_id,
+    category_id: tx.category_id,
+    cleared: tx.cleared,
+    approved: tx.approved,
+    import_id: tx.import_id,
+  };
+}
+
+function isClientError(err: unknown): boolean {
+  if (!(err instanceof YNABError)) return false;
+  return err.statusCode !== undefined && err.statusCode >= 400 && err.statusCode < 500;
+}
+
+/** Create many transactions in one call. Attempts a single bulk POST for
+ * the happy path; on a YNAB 4xx response (which by design aborts the whole
+ * batch and hides which row was at fault), falls back to per-row POSTs so
+ * the caller gets index-aligned success/failure detail. Non-4xx failures
+ * (rate-limit, 5xx, network) surface as a tool-level error rather than
+ * amplifying into per-row retries. */
+export class BatchCreateTransactionsTool extends YnabTool {
+  name = 'ynab_batch_create_transactions';
+  description = 'Create up to 100 transactions in a single batch. Tries one bulk POST; on YNAB validation (4xx) failures, falls back to per-transaction POSTs and reports which rows succeeded and which failed. Preserves cleared=reconciled with approved=true defaults. Amounts in milliunits.';
+  inputSchema = BatchCreateInputSchema;
+
+  async execute(args: unknown): Promise<BatchCreateResult> {
+    const input = this.validateArgs<BatchCreateInput>(args);
+    for (const tx of input.transactions) {
+      assertPayeeNameAllowed(tx.payee_name);
+    }
+
+    try {
+      return await this.bulkCreate(input);
+    } catch (error) {
+      if (isClientError(error) && input.transactions.length > 1) {
+        return await this.fallbackPerTransaction(input);
+      }
+      this.handleError(error, 'batch create transactions');
+    }
+  }
+
+  private async bulkCreate(input: BatchCreateInput): Promise<BatchCreateResult> {
+    const payload = input.transactions.map(toSaveTransaction);
+    const response: YnabTransactionsResponse = await this.client.createTransactions(input.budget_id, payload);
+
+    const created = response.transactions.map((tx, i) => summarize(tx, i));
+    const returnedImportIds = new Set(response.transactions.map(t => t.import_id).filter((v): v is string => !!v));
+    const submittedImportIds = input.transactions.map(t => t.import_id).filter((v): v is string => !!v);
+    const duplicateImportIds = submittedImportIds.filter(id => !returnedImportIds.has(id));
+
+    return {
+      created,
+      failed: [],
+      duplicate_import_ids: duplicateImportIds,
+      server_knowledge: response.server_knowledge,
+      summary: {
+        total_submitted: input.transactions.length,
+        created: created.length,
+        failed: 0,
+        duplicates: duplicateImportIds.length,
+        used_fallback: false,
+      },
+    };
+  }
+
+  private async fallbackPerTransaction(input: BatchCreateInput): Promise<BatchCreateResult> {
+    const created: CreatedTransactionSummary[] = [];
+    const failed: FailedTransaction[] = [];
+    const duplicateImportIds: string[] = [];
+    let serverKnowledge = 0;
+
+    for (let index = 0; index < input.transactions.length; index += 1) {
+      const row = input.transactions[index]!;
+      try {
+        const resp = await this.client.createTransactions(input.budget_id, [toSaveTransaction(row)]);
+        if (!resp.transactions || resp.transactions.length === 0) {
+          if (row.import_id) duplicateImportIds.push(row.import_id);
+          else {
+            failed.push({
+              index,
+              error: 'YNAB returned no transaction (possible silent rejection)',
+              input_summary: { account_id: row.account_id, amount: row.amount, date: row.date },
+            });
+          }
+          continue;
+        }
+        created.push(summarize(resp.transactions[0]!, index));
+        serverKnowledge = resp.server_knowledge;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        failed.push({
+          index,
+          error: message,
+          input_summary: { account_id: row.account_id, amount: row.amount, date: row.date },
+        });
+      }
+    }
+
+    return {
+      created,
+      failed,
+      duplicate_import_ids: duplicateImportIds,
+      server_knowledge: serverKnowledge,
+      summary: {
+        total_submitted: input.transactions.length,
+        created: created.length,
+        failed: failed.length,
+        duplicates: duplicateImportIds.length,
+        used_fallback: true,
+      },
+    };
+  }
+}

--- a/src/tools/transactions/batchCreateTransactions.ts
+++ b/src/tools/transactions/batchCreateTransactions.ts
@@ -4,8 +4,6 @@ import { assertPayeeNameAllowed } from '../common/reservedPayees.js';
 import { YNABError } from '../../client/ErrorHandler.js';
 import type { SaveTransaction, YnabTransaction, YnabTransactionsResponse } from '../../types/index.js';
 
-// One transaction in a batch-create payload. Mirrors create_transaction but
-// makes import_id optional and defaults approved=true (user-initiated).
 const BatchCreateTransactionInputSchema = z.object({
   account_id: z.string().describe('The account ID where the transaction will be created'),
   category_id: z.string().nullable().optional().describe('The category ID for the transaction. Use null for transfers or income'),
@@ -31,7 +29,7 @@ type BatchCreateInput = z.infer<typeof BatchCreateInputSchema>;
 
 interface CreatedTransactionSummary {
   id: string;
-  // Submission index when correlate-able (import_id present or per-row fallback), else null. In bulk mode without import_ids YNAB does not guarantee response order matches submission order.
+  /** Submission index, or null when bulk mode can't correlate (no import_id). */
   index: number | null;
   date: string;
   amount: { milliunits: number; formatted: string };
@@ -52,7 +50,7 @@ export interface BatchCreateResult {
   created: CreatedTransactionSummary[];
   failed: FailedTransaction[];
   duplicate_import_ids: string[];
-  // null when no successful API call was made (e.g. every fallback row failed). Avoids callers confusing 0 with "no prior knowledge" for delta sync.
+  /** null when no successful API call was made — avoids delta-sync callers confusing 0 with "no prior knowledge". */
   server_knowledge: number | null;
   summary: {
     total_submitted: number;
@@ -98,9 +96,7 @@ function summarize(tx: YnabTransaction, index: number | null): CreatedTransactio
   };
 }
 
-// Only YNAB 400 and 409 (conflict) hint at "a specific row is bad." Auth
-// (401/403), rate-limit (429), 5xx, and network errors are system-level
-// problems where per-row fallback would just amplify the damage.
+// Only 400/409 hint at a specific row being at fault; anything else is system-level and per-row fallback would amplify the damage.
 function shouldFallbackOn(err: unknown): boolean {
   if (!(err instanceof YNABError)) return false;
   return err.statusCode === 400 || err.statusCode === 409;
@@ -135,9 +131,7 @@ export class BatchCreateTransactionsTool extends YnabTool {
     const payload = input.transactions.map(toSaveTransaction);
     const response: YnabTransactionsResponse = await this.client.createTransactions(input.budget_id, payload);
 
-    // Correlate created rows back to submission order via import_id when
-    // supplied. Without it, YNAB response order is not guaranteed to match
-    // submission order, so we record index=null for those rows.
+    // YNAB doesn't guarantee bulk response order matches submission order; correlate via import_id when supplied, index=null otherwise.
     const submissionIndexByImportId = new Map<string, number>();
     input.transactions.forEach((t, i) => {
       if (t.import_id) submissionIndexByImportId.set(t.import_id, i);
@@ -190,9 +184,7 @@ export class BatchCreateTransactionsTool extends YnabTool {
         created.push(summarize(resp.transactions[0]!, index));
         serverKnowledge = resp.server_knowledge;
       } catch (error) {
-        // Only client-level 400/409 belong per-row; re-raise anything else
-        // (rate-limit, 5xx, network) instead of silently marking 100 rows
-        // as failed while the server is down.
+        // Re-raise non-4xx (rate-limit, 5xx, network) so we stop hammering a degraded server.
         if (!shouldFallbackOn(error)) throw error;
         const message = error instanceof Error ? error.message : String(error);
         failed.push({

--- a/tests/server/toolRegistry.test.ts
+++ b/tests/server/toolRegistry.test.ts
@@ -178,6 +178,13 @@ describe('Tool Registry', () => {
     });
   });
 
+  describe('Batch create', () => {
+    it('registers batch_create_transactions tool', () => {
+      const tool = registeredTools.find(t => t.name === 'ynab_batch_create_transactions');
+      expect(tool).toBeDefined();
+    });
+  });
+
   describe('Budgeting tools', () => {
     it.each([
       'ynab_auto_assign_underfunded',

--- a/tests/tools/transactions/batchCreateTransactions.test.ts
+++ b/tests/tools/transactions/batchCreateTransactions.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { BatchCreateTransactionsTool } from '../../../src/tools/transactions/batchCreateTransactions.js';
+import { createMockClient, type MockYNABClient } from '../../helpers/mockClient.js';
+import { createMockTransaction } from '../../helpers/fixtures.js';
+import { YNABError } from '../../../src/client/ErrorHandler.js';
+
+describe('BatchCreateTransactionsTool', () => {
+  let client: MockYNABClient;
+  let tool: BatchCreateTransactionsTool;
+
+  beforeEach(() => {
+    client = createMockClient();
+    tool = new BatchCreateTransactionsTool(client as any);
+  });
+
+  describe('metadata', () => {
+    it('has correct name and description mentions batch/create', () => {
+      expect(tool.name).toBe('ynab_batch_create_transactions');
+      expect(tool.description.toLowerCase()).toContain('batch');
+    });
+  });
+
+  describe('input validation', () => {
+    it('requires budget_id and a non-empty transactions array', async () => {
+      await expect(tool.execute({})).rejects.toThrow();
+      await expect(tool.execute({ budget_id: 'b1', transactions: [] })).rejects.toThrow();
+    });
+
+    it('caps the batch at 100 transactions per YNAB API limit', async () => {
+      const big = Array.from({ length: 101 }, () => ({
+        account_id: 'a1', amount: -1000, date: '2024-01-01',
+      }));
+      await expect(tool.execute({ budget_id: 'b1', transactions: big })).rejects.toThrow();
+    });
+
+    it('rejects reserved payee_name on any transaction before any API call', async () => {
+      await expect(tool.execute({
+        budget_id: 'b1',
+        transactions: [
+          { account_id: 'a1', amount: -1000, date: '2024-01-01' },
+          { account_id: 'a1', amount: -2000, date: '2024-01-02', payee_name: 'Reconciliation Balance Adjustment' },
+        ],
+      })).rejects.toThrow(/reserved by YNAB/i);
+      expect(client.createTransactions).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('happy path (bulk POST)', () => {
+    it('creates every transaction in a single bulk POST', async () => {
+      client.createTransactions.mockResolvedValue({
+        transactions: [
+          createMockTransaction({ id: 'tx-1', import_id: 'bulk-1', amount: -1000 }),
+          createMockTransaction({ id: 'tx-2', import_id: 'bulk-2', amount: -2000 }),
+        ],
+        server_knowledge: 42,
+      });
+
+      const result = await tool.execute({
+        budget_id: 'b1',
+        transactions: [
+          { account_id: 'a1', amount: -1000, date: '2024-01-01', import_id: 'bulk-1' },
+          { account_id: 'a1', amount: -2000, date: '2024-01-02', import_id: 'bulk-2' },
+        ],
+      });
+
+      expect(client.createTransactions).toHaveBeenCalledTimes(1);
+      expect(result.created.map(t => t.id)).toEqual(['tx-1', 'tx-2']);
+      expect(result.failed).toHaveLength(0);
+      expect(result.summary.total_submitted).toBe(2);
+      expect(result.summary.created).toBe(2);
+      expect(result.server_knowledge).toBe(42);
+    });
+
+    it('preserves cleared=reconciled + approved=true default without downgrading', async () => {
+      client.createTransactions.mockImplementation(async (_b, txns) => ({
+        transactions: txns.map((t: any, i: number) => createMockTransaction({
+          id: `tx-${i}`,
+          cleared: t.cleared,
+          approved: t.approved,
+        })),
+        server_knowledge: 1,
+      }));
+
+      await tool.execute({
+        budget_id: 'b1',
+        transactions: [
+          { account_id: 'a1', amount: -1000, date: '2024-01-01', cleared: 'reconciled' },
+        ],
+      });
+
+      expect(client.createTransactions).toHaveBeenCalledWith(
+        'b1',
+        expect.arrayContaining([
+          expect.objectContaining({ cleared: 'reconciled', approved: true }),
+        ])
+      );
+    });
+
+    it('surfaces duplicate_import_ids as failures with reason=duplicate_import_id', async () => {
+      // Only one of two returned by YNAB — the other was a duplicate.
+      client.createTransactions.mockResolvedValue({
+        transactions: [createMockTransaction({ id: 'tx-1', import_id: 'bulk-1' })],
+        server_knowledge: 1,
+      });
+
+      const result = await tool.execute({
+        budget_id: 'b1',
+        transactions: [
+          { account_id: 'a1', amount: -1000, date: '2024-01-01', import_id: 'bulk-1' },
+          { account_id: 'a1', amount: -2000, date: '2024-01-02', import_id: 'bulk-2' },
+        ],
+      });
+
+      expect(result.created).toHaveLength(1);
+      expect(result.duplicate_import_ids).toEqual(['bulk-2']);
+      expect(result.summary.duplicates).toBe(1);
+    });
+  });
+
+  describe('per-row fallback on bulk failure', () => {
+    it('falls back to per-transaction POSTs when bulk POST 400s, reporting per-row status', async () => {
+      let bulkCalls = 0;
+      client.createTransactions.mockImplementation(async (_b, txns) => {
+        bulkCalls += 1;
+        if (bulkCalls === 1) {
+          throw new YNABError({ type: 'validation', message: 'Bad request', statusCode: 400 });
+        }
+        // Per-txn fallback (array of 1 each). Fail the one with amount -2000.
+        const t = txns[0] as any;
+        if (t.amount === -2000) {
+          throw new YNABError({ type: 'validation', message: 'category_id invalid', statusCode: 400 });
+        }
+        return {
+          transactions: [createMockTransaction({ id: `tx-${t.amount}`, amount: t.amount })],
+          server_knowledge: 1,
+        };
+      });
+
+      const result = await tool.execute({
+        budget_id: 'b1',
+        transactions: [
+          { account_id: 'a1', amount: -1000, date: '2024-01-01' },
+          { account_id: 'a1', amount: -2000, date: '2024-01-02', category_id: 'bad' },
+          { account_id: 'a1', amount: -3000, date: '2024-01-03' },
+        ],
+      });
+
+      expect(result.created).toHaveLength(2);
+      expect(result.failed).toHaveLength(1);
+      expect(result.failed[0]!.index).toBe(1);
+      expect(result.failed[0]!.error).toMatch(/category_id/i);
+      expect(result.summary.created).toBe(2);
+      expect(result.summary.failed).toBe(1);
+    });
+
+    it('rethrows on non-4xx bulk failures rather than hammering with fallback', async () => {
+      client.createTransactions.mockRejectedValue(
+        new YNABError({ type: 'rate_limit', message: '429', statusCode: 429 })
+      );
+      await expect(tool.execute({
+        budget_id: 'b1',
+        transactions: [{ account_id: 'a1', amount: -1000, date: '2024-01-01' }],
+      })).rejects.toThrow(/batch create transactions failed/i);
+      expect(client.createTransactions).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/tests/tools/transactions/batchCreateTransactions.test.ts
+++ b/tests/tools/transactions/batchCreateTransactions.test.ts
@@ -163,5 +163,108 @@ describe('BatchCreateTransactionsTool', () => {
       })).rejects.toThrow(/batch create transactions failed/i);
       expect(client.createTransactions).toHaveBeenCalledTimes(1);
     });
+
+    it('does NOT trigger per-row fallback on 401 auth errors', async () => {
+      client.createTransactions.mockRejectedValue(
+        new YNABError({ type: 'auth', message: 'Unauthorized', statusCode: 401 })
+      );
+      await expect(tool.execute({
+        budget_id: 'b1',
+        transactions: [
+          { account_id: 'a1', amount: -1000, date: '2024-01-01' },
+          { account_id: 'a1', amount: -2000, date: '2024-01-02' },
+        ],
+      })).rejects.toThrow(/batch create transactions failed/i);
+      // only the single bulk attempt; no 2 per-row retries
+      expect(client.createTransactions).toHaveBeenCalledTimes(1);
+    });
+
+    it('rethrows when a rate-limit occurs mid-fallback (stop hammering)', async () => {
+      let calls = 0;
+      client.createTransactions.mockImplementation(async () => {
+        calls += 1;
+        if (calls === 1) {
+          throw new YNABError({ type: 'validation', message: 'Bad request', statusCode: 400 });
+        }
+        if (calls === 3) {
+          throw new YNABError({ type: 'rate_limit', message: '429', statusCode: 429 });
+        }
+        return {
+          transactions: [createMockTransaction({ id: `tx-${calls}` })],
+          server_knowledge: 1,
+        };
+      });
+
+      await expect(tool.execute({
+        budget_id: 'b1',
+        transactions: [
+          { account_id: 'a1', amount: -1000, date: '2024-01-01' },
+          { account_id: 'a1', amount: -2000, date: '2024-01-02' },
+          { account_id: 'a1', amount: -3000, date: '2024-01-03' },
+        ],
+      })).rejects.toThrow(/batch create transactions failed/i);
+      // bulk + row 1 success + row 2 rate-limited (stop here, don't continue)
+      expect(client.createTransactions).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('index correlation', () => {
+    it('correlates bulk happy-path rows back to submission order via import_id', async () => {
+      // YNAB returns rows in reversed order — check we still map them correctly.
+      client.createTransactions.mockResolvedValue({
+        transactions: [
+          createMockTransaction({ id: 'tx-2', import_id: 'bulk-2' }),
+          createMockTransaction({ id: 'tx-1', import_id: 'bulk-1' }),
+        ],
+        server_knowledge: 1,
+      });
+
+      const result = await tool.execute({
+        budget_id: 'b1',
+        transactions: [
+          { account_id: 'a1', amount: -1000, date: '2024-01-01', import_id: 'bulk-1' },
+          { account_id: 'a1', amount: -2000, date: '2024-01-02', import_id: 'bulk-2' },
+        ],
+      });
+
+      const byId = Object.fromEntries(result.created.map(r => [r.id, r.index]));
+      expect(byId['tx-1']).toBe(0);
+      expect(byId['tx-2']).toBe(1);
+    });
+
+    it('leaves index=null for bulk rows without import_id (response order is not guaranteed)', async () => {
+      client.createTransactions.mockResolvedValue({
+        transactions: [createMockTransaction({ id: 'tx-a' })],
+        server_knowledge: 1,
+      });
+      const result = await tool.execute({
+        budget_id: 'b1',
+        transactions: [{ account_id: 'a1', amount: -1000, date: '2024-01-01' }],
+      });
+      expect(result.created[0]!.index).toBeNull();
+    });
+  });
+
+  describe('server_knowledge nullability', () => {
+    it('returns null server_knowledge when every fallback row fails', async () => {
+      let calls = 0;
+      client.createTransactions.mockImplementation(async () => {
+        calls += 1;
+        if (calls === 1) {
+          throw new YNABError({ type: 'validation', message: 'Bad request', statusCode: 400 });
+        }
+        throw new YNABError({ type: 'validation', message: 'row bad', statusCode: 400 });
+      });
+
+      const result = await tool.execute({
+        budget_id: 'b1',
+        transactions: [
+          { account_id: 'a1', amount: -1000, date: '2024-01-01' },
+          { account_id: 'a1', amount: -2000, date: '2024-01-02' },
+        ],
+      });
+      expect(result.server_knowledge).toBeNull();
+      expect(result.failed).toHaveLength(2);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Closes #13
- New tool \`ynab_batch_create_transactions\` fills the gap between \`ynab_create_transaction\` (per-txn, slow for bulk) and \`ynab_import_transactions\` (feed-style semantics: required \`import_id\`, hardcoded \`approved: false\` quirks).
- Accepts up to 100 transactions with the same field set as \`create_transaction\` (optional \`import_id\`, \`approved: true\` default, preserves \`cleared: reconciled\` as-is).
- **Strategy**: one bulk POST for the happy path; on a YNAB 4xx (which by design aborts the whole batch and hides the offending row), automatically falls back to per-row POSTs and returns index-aligned success/failure detail. Exactly what the issue asked for, but without burning 100 requests on every valid batch.
- Non-4xx failures (rate-limit, 5xx, network) surface at the tool level rather than amplifying into per-row retries.
- Reserved-payee validation runs before any API call.

## Response shape
\`\`\`
{
  created: [{ id, index, date, amount, account_id, category_id, cleared, approved, import_id }],
  failed:  [{ index, error, input_summary: { account_id, amount, date } }],
  duplicate_import_ids: [...],
  server_knowledge,
  summary: { total_submitted, created, failed, duplicates, used_fallback }
}
\`\`\`

## Test plan
- [x] 9 red/green tests covering: metadata, empty-array + >100 validation, reserved-payee pre-check, happy-path bulk, cleared=reconciled preservation, duplicate_import_ids, per-row fallback on 4xx, non-4xx rethrow.
- [x] Registry test covers the new tool.
- [x] \`npm test\` — 435 passed, 2 skipped.
- [x] \`npm run lint\` clean.
- [x] Bumped to v1.5.0 (new tool).