### PR TITLE
feat(budgeting): reduce overfunded categories in auto_balance_month

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ynab-mcp-server",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Comprehensive Model Context Protocol server providing intelligent access to YNAB (You Need A Budget) data with AI-powered budget recommendations, spending analysis, and complete transaction management",
   "type": "module",
   "main": "dist/index.js",

--- a/src/tools/budgeting/autoBalanceMonth.ts
+++ b/src/tools/budgeting/autoBalanceMonth.ts
@@ -48,21 +48,25 @@ export class AutoBalanceMonthTool extends YnabTool {
 
       const phases: BudgetingResult[] = [sweepResult];
 
-      // Phase 2 (optional): reduce overfunded. Refresh the month so balances
-      // reflect the sweep PATCHes (unless dry_run). Reuses closed-CC names.
+      // Phase 2 (optional): reduce overfunded. In live mode, re-fetch so
+      // balances reflect the sweep PATCHes. In dry_run, simulate the sweep's
+      // planned changes against the in-memory context — otherwise the same
+      // category (e.g. a refund) shows up in both phases' details and inflates
+      // the simulated totals.
       let nextCtx: BudgetingContext = sweepCtx;
       if (input.reduce_overfunded) {
         nextCtx = input.dry_run
-          ? sweepCtx
+          ? applyPlannedToContext(sweepCtx, sweepResult)
           : await loadMonthOnlyContext(this.client, input, sweepCtx.closedCcAccountNames);
         const reduceResult = await reduce.executeWithContext(input, nextCtx);
         phases.push(reduceResult);
       }
 
-      // Phase 3: assign. Refresh again so balances reflect any reduce
-      // PATCHes (unless dry_run, in which case the prior context is reused).
+      // Phase 3: assign. Same dry_run treatment — simulate the prior phase's
+      // planned changes forward.
+      const lastPhaseResult = phases[phases.length - 1]!;
       const assignCtx = input.dry_run
-        ? nextCtx
+        ? applyPlannedToContext(nextCtx, lastPhaseResult)
         : await loadMonthOnlyContext(this.client, input, sweepCtx.closedCcAccountNames);
       const assignResult = await assign.executeWithContext(input, assignCtx);
       phases.push(assignResult);
@@ -77,6 +81,35 @@ export class AutoBalanceMonthTool extends YnabTool {
       this.handleError(error, 'auto-balance month');
     }
   }
+}
+
+/** Advance an in-memory context forward by applying a phase's planned
+ * changes. Used for dry_run between phases — without this, every phase
+ * sees the original pre-sweep state and the same category can appear in
+ * multiple phases' planned details. */
+function applyPlannedToContext(ctx: BudgetingContext, result: BudgetingResult): BudgetingContext {
+  const deltaByCat = new Map<string, number>();
+  for (const d of result.details) {
+    if (d.status === 'planned' || d.status === 'applied') {
+      deltaByCat.set(d.category_id, d.delta);
+    }
+  }
+  if (deltaByCat.size === 0) return ctx;
+
+  const updatedCategories = ctx.categories.map(c => {
+    const delta = deltaByCat.get(c.id);
+    if (delta === undefined || delta === 0) return c;
+    return { ...c, budgeted: c.budgeted + delta, balance: c.balance + delta };
+  });
+
+  // RTA moves opposite to budgeted: +budgeted means -RTA.
+  const totalBudgetedDelta = Array.from(deltaByCat.values()).reduce((s, d) => s + d, 0);
+
+  return {
+    ...ctx,
+    categories: updatedCategories,
+    toBeBudgetedBefore: ctx.toBeBudgetedBefore - totalBudgetedDelta,
+  };
 }
 
 async function loadMonthOnlyContext(

--- a/src/tools/budgeting/autoBalanceMonth.ts
+++ b/src/tools/budgeting/autoBalanceMonth.ts
@@ -1,5 +1,7 @@
+import { z } from 'zod';
 import { YnabTool } from '../base.js';
 import { AutoSweepPositivesTool } from './autoSweepPositives.js';
+import { AutoReduceOverfundedTool } from './autoReduceOverfunded.js';
 import { AutoAssignUnderfundedTool } from './autoAssignUnderfunded.js';
 import {
   BaseBudgetingInputSchema,
@@ -9,6 +11,12 @@ import {
   type BudgetingResult,
 } from './shared.js';
 
+export const BalanceMonthInputSchema = BaseBudgetingInputSchema.extend({
+  reduce_overfunded: z.boolean().optional().default(true).describe('Run the reduce-overfunded phase between sweep and assign. Frees money stuck in over-funded categories (preserves prior-month carryover; skips goals). Default true. Set false to restore the original two-phase behavior.'),
+});
+
+export type BalanceMonthInput = z.infer<typeof BalanceMonthInputSchema>;
+
 export interface BalanceMonthResult {
   phase: 'balance_month';
   dry_run: boolean;
@@ -16,36 +24,49 @@ export interface BalanceMonthResult {
   total_moved_milliunits: number;
 }
 
-/** Runs sweep-positives then assign-underfunded in order. Loads accounts +
- * month once for the sweep phase, then re-fetches only the month between
- * phases (the PATCHes in sweep change `budgeted`/`activity` and the assign
- * phase needs fresh balances). The account list is reused across phases to
- * avoid a redundant GET /accounts call. */
+/** Runs sweep-positives → reduce-overfunded → assign-underfunded in order.
+ * Loads accounts + month once for the first phase, then re-fetches only
+ * the month between phases (each PATCH set changes `budgeted`/`activity`
+ * and the next phase needs fresh balances). The account list is reused
+ * across phases to avoid redundant GET /accounts calls. */
 export class AutoBalanceMonthTool extends YnabTool {
   name = 'ynab_auto_balance_month';
-  description = 'Run sweep-positives then auto-assign-underfunded for a month in one call. Loads context once and reuses the account list across phases to conserve rate-limit budget. Supports dry_run.';
-  inputSchema = BaseBudgetingInputSchema;
+  description = 'Run sweep-positives, reduce-overfunded, then auto-assign-underfunded for a month in one call. Loads context once and reuses the account list across phases to conserve rate-limit budget. Pass reduce_overfunded:false to skip the middle phase. Supports dry_run.';
+  inputSchema = BalanceMonthInputSchema;
 
   async execute(args: unknown): Promise<BalanceMonthResult> {
-    const input = this.validateArgs<BaseBudgetingInput>(args);
+    const input = this.validateArgs<BalanceMonthInput>(args);
 
     try {
       const sweep = new AutoSweepPositivesTool(this.client);
+      const reduce = new AutoReduceOverfundedTool(this.client);
       const assign = new AutoAssignUnderfundedTool(this.client);
 
       // Phase 1: sweep. One context load (month + accounts).
       const sweepCtx = await loadBudgetingContext(this.client, input);
       const sweepResult = await sweep.executeWithContext(input, sweepCtx);
 
-      // Phase 2: assign. Reuse the closed-CC account names from phase 1 —
-      // closed status doesn't change mid-run — but refresh the month so
-      // balances reflect the sweep PATCHes we just issued (unless dry_run).
+      const phases: BudgetingResult[] = [sweepResult];
+
+      // Phase 2 (optional): reduce overfunded. Refresh the month so balances
+      // reflect the sweep PATCHes (unless dry_run). Reuses closed-CC names.
+      let nextCtx: BudgetingContext = sweepCtx;
+      if (input.reduce_overfunded) {
+        nextCtx = input.dry_run
+          ? sweepCtx
+          : await loadMonthOnlyContext(this.client, input, sweepCtx.closedCcAccountNames);
+        const reduceResult = await reduce.executeWithContext(input, nextCtx);
+        phases.push(reduceResult);
+      }
+
+      // Phase 3: assign. Refresh again so balances reflect any reduce
+      // PATCHes (unless dry_run, in which case the prior context is reused).
       const assignCtx = input.dry_run
-        ? sweepCtx
+        ? nextCtx
         : await loadMonthOnlyContext(this.client, input, sweepCtx.closedCcAccountNames);
       const assignResult = await assign.executeWithContext(input, assignCtx);
+      phases.push(assignResult);
 
-      const phases = [sweepResult, assignResult];
       return {
         phase: 'balance_month',
         dry_run: input.dry_run,

--- a/src/tools/budgeting/autoReduceOverfunded.ts
+++ b/src/tools/budgeting/autoReduceOverfunded.ts
@@ -48,12 +48,18 @@ export class AutoReduceOverfundedTool extends YnabTool {
         const protectedFloor = Math.max(0, carryover);
         const excess = c.balance - protectedFloor;
         if (excess <= 0) return null;
+        // Never drive `budgeted` below zero. A refund (positive activity)
+        // can push balance above budgeted; that surplus belongs to
+        // sweep_positives, not here. Clamp so standalone use is safe.
+        const newBudgeted = Math.max(0, c.budgeted - excess);
+        const actualDelta = newBudgeted - c.budgeted;
+        if (actualDelta === 0) return null;
         return {
           category_id: c.id,
           category_name: c.name,
           previous_budgeted: c.budgeted,
-          new_budgeted: c.budgeted - excess,
-          delta: -excess,
+          new_budgeted: newBudgeted,
+          delta: actualDelta,
         } as PlannedChange;
       })
       .filter((change): change is PlannedChange => change !== null);

--- a/src/tools/budgeting/autoReduceOverfunded.ts
+++ b/src/tools/budgeting/autoReduceOverfunded.ts
@@ -1,0 +1,88 @@
+import { YnabTool } from '../base.js';
+import { filterCategories, priorCarryover } from './categoryFilters.js';
+import { applyBudgetChanges, type PlannedChange } from './categoryBudgetApplier.js';
+import {
+  BaseBudgetingInputSchema,
+  buildFilterOptions,
+  loadBudgetingContext,
+  refreshToBeBudgeted,
+  wrapAmount,
+  formatAmount,
+  type BaseBudgetingInput,
+  type BudgetingContext,
+  type BudgetingResult,
+} from './shared.js';
+
+/** Frees money stuck in overfunded categories — the symmetrical counterpart
+ * to AutoSweepPositives. After re-categorizing transactions out of a
+ * category (e.g. moving spend from "Other" into more specific categories),
+ * the original category is left over-funded relative to its now-tiny
+ * activity. This tool reduces `budgeted` so the surplus returns to RTA,
+ * while preserving any prior-month carryover (treated as savings) and
+ * skipping every category with a goal. */
+export class AutoReduceOverfundedTool extends YnabTool {
+  name = 'ynab_auto_reduce_overfunded';
+  description = 'Reduce `budgeted` for over-funded categories so excess returns to Ready-to-Assign. Frees the portion above prior-month carryover. Skips categories with goals, closed CC payment categories, hidden, and deleted categories. Supports dry_run.';
+  inputSchema = BaseBudgetingInputSchema;
+
+  async execute(args: unknown): Promise<BudgetingResult> {
+    const input = this.validateArgs<BaseBudgetingInput>(args);
+    try {
+      const ctx = await loadBudgetingContext(this.client, input);
+      return await this.executeWithContext(input, ctx);
+    } catch (error) {
+      this.handleError(error, 'auto-reduce overfunded');
+    }
+  }
+
+  /** Execute against a caller-supplied context; used by AutoBalanceMonth.
+   * Errors are NOT caught here — the outer `execute()` or the composing
+   * tool owns error wrapping so we don't double-wrap messages. */
+  async executeWithContext(input: BaseBudgetingInput, ctx: BudgetingContext): Promise<BudgetingResult> {
+    const filterOpts = buildFilterOptions(input, ctx.closedCcAccountNames, { skip_goals: true });
+    const { kept, skipped } = filterCategories(ctx.categories, filterOpts);
+
+    const changes: PlannedChange[] = kept
+      .map(c => {
+        const carryover = priorCarryover(c);
+        const protectedFloor = Math.max(0, carryover);
+        const excess = c.balance - protectedFloor;
+        if (excess <= 0) return null;
+        return {
+          category_id: c.id,
+          category_name: c.name,
+          previous_budgeted: c.budgeted,
+          new_budgeted: c.budgeted - excess,
+          delta: -excess,
+        } as PlannedChange;
+      })
+      .filter((change): change is PlannedChange => change !== null);
+
+    const result = await applyBudgetChanges(
+      this.client,
+      input.budget_id,
+      input.month,
+      changes,
+      { dry_run: input.dry_run }
+    );
+
+    const toBeBudgetedAfter = await refreshToBeBudgeted(
+      this.client,
+      input.budget_id,
+      input.month,
+      input.dry_run
+    );
+
+    return {
+      phase: 'reduce_overfunded',
+      dry_run: input.dry_run,
+      categories_touched: result.applied,
+      total_moved_milliunits: result.total_moved_milliunits,
+      to_be_budgeted_before: formatAmount(ctx.toBeBudgetedBefore),
+      to_be_budgeted_after: wrapAmount(toBeBudgetedAfter),
+      skipped,
+      details: result.details,
+      failed: result.failed,
+    };
+  }
+}

--- a/src/tools/budgeting/categoryFilters.ts
+++ b/src/tools/budgeting/categoryFilters.ts
@@ -39,6 +39,8 @@ export interface CategoryFilterOptions {
   closed_cc_account_names?: string[];
   /** Skip categories that have a savings goal and carry a positive balance over from the previous month. Default false; sweep-style tools opt in. */
   skip_goal_carryover?: boolean;
+  /** Skip every category with a goal (regardless of carryover). Default false; the reduce-overfunded phase opts in so it never claws back goal funding. */
+  skip_goals?: boolean;
 }
 
 export interface FilteredCategory {
@@ -52,6 +54,7 @@ export interface FilteredCategory {
     | 'ready_to_assign'
     | 'closed_cc'
     | 'goal_carryover'
+    | 'goal'
     /** Tool-specific: category did not exist in the month being copied from (assign-same-as-last-month). */
     | 'no_prior_month'
     /** Tool-specific: no outflow in the lookback window (assign-average-spend). */
@@ -120,6 +123,10 @@ export function filterCategories(
       closedSet.has(normalize(c.name))
     ) {
       skipped.push({ ...entry, reason: 'closed_cc' });
+      continue;
+    }
+    if (options.skip_goals && c.goal_type != null) {
+      skipped.push({ ...entry, reason: 'goal' });
       continue;
     }
     if (

--- a/src/tools/budgeting/index.ts
+++ b/src/tools/budgeting/index.ts
@@ -1,5 +1,6 @@
 export { AutoAssignUnderfundedTool } from './autoAssignUnderfunded.js';
 export { AutoSweepPositivesTool } from './autoSweepPositives.js';
+export { AutoReduceOverfundedTool } from './autoReduceOverfunded.js';
 export { AutoBalanceMonthTool } from './autoBalanceMonth.js';
 export { ResetAvailableAmountsTool } from './resetAvailableAmounts.js';
 export { AssignSameAsLastMonthTool } from './assignSameAsLastMonth.js';

--- a/src/tools/budgeting/shared.ts
+++ b/src/tools/budgeting/shared.ts
@@ -54,7 +54,7 @@ export async function loadBudgetingContext(
 export function buildFilterOptions(
   input: BaseBudgetingInput,
   closedCcAccountNames: string[],
-  extra: Pick<CategoryFilterOptions, 'skip_goal_carryover'> = {}
+  extra: Pick<CategoryFilterOptions, 'skip_goal_carryover' | 'skip_goals'> = {}
 ): CategoryFilterOptions {
   const opts: CategoryFilterOptions = {
     skip_hidden: input.skip_hidden,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -39,6 +39,7 @@ import { DistributeToBebudgetedTool } from './analysis/distributeToBebudgeted.js
 import {
   AutoAssignUnderfundedTool,
   AutoSweepPositivesTool,
+  AutoReduceOverfundedTool,
   AutoBalanceMonthTool,
   ResetAvailableAmountsTool,
   AssignSameAsLastMonthTool,
@@ -108,6 +109,7 @@ export function registerTools(client: YNABClient): Tool[] {
     // Batch monthly budgeting tools
     new AutoAssignUnderfundedTool(client),
     new AutoSweepPositivesTool(client),
+    new AutoReduceOverfundedTool(client),
     new AutoBalanceMonthTool(client),
     new ResetAvailableAmountsTool(client),
     new AssignSameAsLastMonthTool(client),

--- a/tests/tools/budgeting/autoBalanceMonth.test.ts
+++ b/tests/tools/budgeting/autoBalanceMonth.test.ts
@@ -106,6 +106,30 @@ describe('AutoBalanceMonthTool', () => {
     ]);
   });
 
+  it('dry_run simulates each phase forward — refund category does not double-count', async () => {
+    // Pure refund: budgeted=0, activity=10000, balance=10000.
+    // Sweep would PATCH to budgeted=-10000 (delta=-10000).
+    // After simulation, balance becomes 0 → reduce sees nothing to do.
+    // Without forward-simulation, reduce would re-plan this same category
+    // (clamped to 0 delta) and assign would see balance > 0 still.
+    const refund = createMockCategory({
+      id: 'c-refund', name: 'Amazon', category_group_name: 'Shopping', goal_type: null,
+      budgeted: 0, activity: 10000, balance: 10000,
+    });
+    client.getBudgetMonth.mockResolvedValue(monthResponse([refund]));
+
+    const result = await tool.execute({
+      budget_id: 'b1', month: '2024-01-01', dry_run: true, skip_closed_cc_categories: false,
+    });
+
+    const [sweep, reduce, assign] = result.phases;
+    expect(sweep!.categories_touched).toBe(1);
+    expect(reduce!.categories_touched).toBe(0);
+    expect(assign!.categories_touched).toBe(0);
+    // Total moved should equal sweep alone, not sweep+reduce double-count.
+    expect(result.total_moved_milliunits).toBe(10000);
+  });
+
   it('reduce_overfunded:false skips the middle phase (back to original two-phase behavior)', async () => {
     const refund = createMockCategory({
       id: 'c-refund', name: 'Amazon', category_group_name: 'Shopping', goal_type: null,

--- a/tests/tools/budgeting/autoBalanceMonth.test.ts
+++ b/tests/tools/budgeting/autoBalanceMonth.test.ts
@@ -22,34 +22,63 @@ describe('AutoBalanceMonthTool', () => {
     tool = new AutoBalanceMonthTool(client as any);
   });
 
-  it('runs sweep first then assign, reporting both phases', async () => {
-    const refund = createMockCategory({
-      id: 'c-refund', name: 'Amazon', category_group_name: 'Shopping',
+  it('runs sweep, reduce, then assign by default, reporting all three phases', async () => {
+    // Phase 1 sees refund as a sweep target. After sweep, refund's balance
+    // would be 0 in YNAB; the mock has to be told that so phase 2 doesn't
+    // re-touch it. Same idea between phase 2 and phase 3.
+    const refundBeforeSweep = createMockCategory({
+      id: 'c-refund', name: 'Amazon', category_group_name: 'Shopping', goal_type: null,
       budgeted: 0, activity: 10000, balance: 10000,
     });
+    const refundAfterSweep = createMockCategory({
+      id: 'c-refund', name: 'Amazon', category_group_name: 'Shopping', goal_type: null,
+      budgeted: -10000, activity: 10000, balance: 0,
+    });
+    const overfunded = createMockCategory({
+      id: 'c-other', name: 'Other', category_group_name: 'Misc', goal_type: null,
+      // budgeted 7584, activity -28 (small spend), balance 7556 — issue #22 repro
+      budgeted: 7584000, activity: -28000, balance: 7556000,
+    });
+    const overfundedAfterReduce = createMockCategory({
+      id: 'c-other', name: 'Other', category_group_name: 'Misc', goal_type: null,
+      budgeted: 28000, activity: -28000, balance: 0,
+    });
     const underfunded = createMockCategory({
-      id: 'c-under', name: 'Groceries', category_group_name: 'Spending',
+      id: 'c-under', name: 'Groceries', category_group_name: 'Spending', goal_type: null,
       budgeted: 0, activity: -40000, balance: -40000,
     });
-    client.getBudgetMonth.mockResolvedValue(monthResponse([refund, underfunded], 100000));
+
+    client.getBudgetMonth
+      // initial load + post-sweep refresh + post-reduce refresh + final refreshToBeBudgeted calls
+      .mockResolvedValueOnce(monthResponse([refundBeforeSweep, overfunded, underfunded], 100000))
+      .mockResolvedValueOnce(monthResponse([refundBeforeSweep, overfunded, underfunded], 100000)) // sweep refreshToBeBudgeted
+      .mockResolvedValueOnce(monthResponse([refundAfterSweep, overfunded, underfunded], 110000)) // reduce phase load
+      .mockResolvedValueOnce(monthResponse([refundAfterSweep, overfunded, underfunded], 110000)) // reduce refreshToBeBudgeted
+      .mockResolvedValueOnce(monthResponse([refundAfterSweep, overfundedAfterReduce, underfunded], 7666000)) // assign phase load
+      .mockResolvedValue(monthResponse([refundAfterSweep, overfundedAfterReduce, underfunded], 7626000)); // assign refreshToBeBudgeted (and any extras)
 
     const result = await tool.execute({ budget_id: 'b1', month: '2024-01-01', skip_closed_cc_categories: false });
 
-    expect(result.phases.map(p => p.phase)).toEqual(['sweep_positives', 'assign_underfunded']);
-    const sweep = result.phases[0]!;
-    const assign = result.phases[1]!;
-    expect(sweep.categories_touched).toBe(1);
-    expect(assign.categories_touched).toBe(1);
-    expect(result.total_moved_milliunits).toBe(50000); // 10k sweep + 40k assign
+    expect(result.phases.map(p => p.phase)).toEqual([
+      'sweep_positives',
+      'reduce_overfunded',
+      'assign_underfunded',
+    ]);
+    const [sweep, reduce, assign] = result.phases;
+    expect(sweep!.categories_touched).toBe(1);
+    expect(reduce!.categories_touched).toBe(1);
+    expect(assign!.categories_touched).toBe(1);
+    // 10k swept + 7,556k reduced + 40k assigned
+    expect(result.total_moved_milliunits).toBe(10000 + 7556000 + 40000);
   });
 
-  it('loads accounts once across both phases (rate-limit conservation)', async () => {
+  it('loads accounts once across all phases (rate-limit conservation)', async () => {
     const refund = createMockCategory({
-      id: 'c-refund', name: 'Amazon', category_group_name: 'Shopping',
+      id: 'c-refund', name: 'Amazon', category_group_name: 'Shopping', goal_type: null,
       budgeted: 0, activity: 10000, balance: 10000,
     });
     const underfunded = createMockCategory({
-      id: 'c-under', name: 'Groceries', category_group_name: 'Spending',
+      id: 'c-under', name: 'Groceries', category_group_name: 'Spending', goal_type: null,
       budgeted: 0, activity: -40000, balance: -40000,
     });
     client.getBudgetMonth.mockResolvedValue(monthResponse([refund, underfunded]));
@@ -59,9 +88,9 @@ describe('AutoBalanceMonthTool', () => {
     expect(client.getAccounts).toHaveBeenCalledTimes(1);
   });
 
-  it('dry_run bubbles through to both phases', async () => {
+  it('dry_run bubbles through to all phases', async () => {
     const refund = createMockCategory({
-      id: 'c-refund', name: 'Amazon', category_group_name: 'Shopping',
+      id: 'c-refund', name: 'Amazon', category_group_name: 'Shopping', goal_type: null,
       budgeted: 0, activity: 10000, balance: 10000,
     });
     client.getBudgetMonth.mockResolvedValue(monthResponse([refund]));
@@ -70,5 +99,32 @@ describe('AutoBalanceMonthTool', () => {
 
     expect(client.updateCategoryBudget).not.toHaveBeenCalled();
     expect(result.phases.every(p => p.dry_run)).toBe(true);
+    expect(result.phases.map(p => p.phase)).toEqual([
+      'sweep_positives',
+      'reduce_overfunded',
+      'assign_underfunded',
+    ]);
+  });
+
+  it('reduce_overfunded:false skips the middle phase (back to original two-phase behavior)', async () => {
+    const refund = createMockCategory({
+      id: 'c-refund', name: 'Amazon', category_group_name: 'Shopping', goal_type: null,
+      budgeted: 0, activity: 10000, balance: 10000,
+    });
+    const overfunded = createMockCategory({
+      id: 'c-other', name: 'Other', category_group_name: 'Misc', goal_type: null,
+      budgeted: 7584000, activity: -28000, balance: 7556000,
+    });
+    client.getBudgetMonth.mockResolvedValue(monthResponse([refund, overfunded]));
+
+    const result = await tool.execute({
+      budget_id: 'b1', month: '2024-01-01',
+      skip_closed_cc_categories: false,
+      reduce_overfunded: false,
+    });
+
+    expect(result.phases.map(p => p.phase)).toEqual(['sweep_positives', 'assign_underfunded']);
+    // overfunded category is NOT touched when reduce_overfunded is off
+    expect(client.updateCategoryBudget).not.toHaveBeenCalledWith('b1', 'c-other', expect.anything(), expect.anything());
   });
 });

--- a/tests/tools/budgeting/autoReduceOverfunded.test.ts
+++ b/tests/tools/budgeting/autoReduceOverfunded.test.ts
@@ -96,6 +96,39 @@ describe('AutoReduceOverfundedTool', () => {
     expect(result.categories_touched).toBe(0);
   });
 
+  it('never sets budgeted below zero on a pure-refund category (defers to sweep)', async () => {
+    // Refund only: budgeted=0, activity=10000, balance=10000, carryover=0.
+    // Without clamping, excess=10000 → new_budgeted=-10000 (a sweep, not a reduce).
+    // Standalone, this should be skipped: refunds belong to sweep_positives.
+    const refund = createMockCategory({
+      id: 'c-refund', name: 'Amazon', category_group_name: 'Shopping', goal_type: null,
+      budgeted: 0, activity: 10000, balance: 10000,
+    });
+    client.getBudgetMonth.mockResolvedValue(monthResponse([refund]));
+
+    const result = await tool.execute({ budget_id: 'b1', month: '2024-01-01', skip_closed_cc_categories: false });
+
+    expect(client.updateCategoryBudget).not.toHaveBeenCalled();
+    expect(result.categories_touched).toBe(0);
+  });
+
+  it('partially reduces an over-funded category that also has a refund (clamps at 0)', async () => {
+    // budgeted=5000, activity=10000 (refund), balance=15000, carryover=0
+    // Naive: new_budgeted = 5000 - 15000 = -10000 (would over-claim)
+    // Clamped: new_budgeted = 0, delta = -5000 — frees only the over-budgeted
+    // portion; the 10k refund stays for sweep_positives to handle.
+    const mixed = createMockCategory({
+      id: 'c-mixed', name: 'Mixed', category_group_name: 'G', goal_type: null,
+      budgeted: 5000, activity: 10000, balance: 15000,
+    });
+    client.getBudgetMonth.mockResolvedValue(monthResponse([mixed]));
+
+    const result = await tool.execute({ budget_id: 'b1', month: '2024-01-01', skip_closed_cc_categories: false });
+
+    expect(client.updateCategoryBudget).toHaveBeenCalledWith('b1', 'c-mixed', '2024-01-01', 0);
+    expect(result.total_moved_milliunits).toBe(5000);
+  });
+
   it('skips a category whose entire positive balance is prior carryover (no excess)', async () => {
     // budgeted=0, activity=0, balance=1000 → carryover=1000, excess=0 → no change
     const savedUp = createMockCategory({

--- a/tests/tools/budgeting/autoReduceOverfunded.test.ts
+++ b/tests/tools/budgeting/autoReduceOverfunded.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { AutoReduceOverfundedTool } from '../../../src/tools/budgeting/autoReduceOverfunded.js';
+import { createMockClient, type MockYNABClient } from '../../helpers/mockClient.js';
+import { createMockCategory } from '../../helpers/fixtures.js';
+
+function monthResponse(categories: any[], to_be_budgeted = 0) {
+  return {
+    month: {
+      month: '2024-01-01', note: null, income: 0, budgeted: 0, activity: 0,
+      to_be_budgeted, age_of_money: null, deleted: false, categories,
+    },
+    server_knowledge: 1,
+  };
+}
+
+describe('AutoReduceOverfundedTool', () => {
+  let client: MockYNABClient;
+  let tool: AutoReduceOverfundedTool;
+
+  beforeEach(() => {
+    client = createMockClient();
+    tool = new AutoReduceOverfundedTool(client as any);
+  });
+
+  it('reduces a plain over-funded category back to its activity floor (issue #22 repro)', async () => {
+    // Budgeted $7,584, only $28 spent (activity = -28000), no carryover, no goal.
+    // Expect new_budgeted = 28000 (i.e., -activity), freeing $7,556 to RTA.
+    const other = createMockCategory({
+      id: 'c-other', name: 'Other', category_group_name: 'Misc',
+      goal_type: null,
+      budgeted: 7584000, activity: -28000, balance: 7556000,
+    });
+    client.getBudgetMonth.mockResolvedValue(monthResponse([other]));
+
+    const result = await tool.execute({ budget_id: 'b1', month: '2024-01-01', skip_closed_cc_categories: false });
+
+    expect(client.updateCategoryBudget).toHaveBeenCalledTimes(1);
+    expect(client.updateCategoryBudget).toHaveBeenCalledWith('b1', 'c-other', '2024-01-01', 28000);
+    expect(result.phase).toBe('reduce_overfunded');
+    expect(result.categories_touched).toBe(1);
+    expect(result.total_moved_milliunits).toBe(7556000);
+  });
+
+  it('preserves prior-month carryover (only frees the excess above carryover)', async () => {
+    // prior_carryover = balance - budgeted - activity = 3000 - 2000 - 0 = 1000
+    // protectedFloor = 1000, excess = 3000 - 1000 = 2000
+    // new_budgeted = 2000 - 2000 = 0
+    const slush = createMockCategory({
+      id: 'c-slush', name: 'Slush', category_group_name: 'Misc',
+      goal_type: null,
+      budgeted: 2000000, activity: 0, balance: 3000000,
+    });
+    client.getBudgetMonth.mockResolvedValue(monthResponse([slush]));
+
+    await tool.execute({ budget_id: 'b1', month: '2024-01-01', skip_closed_cc_categories: false });
+
+    expect(client.updateCategoryBudget).toHaveBeenCalledWith('b1', 'c-slush', '2024-01-01', 0);
+  });
+
+  it('skips every category with a goal (regardless of carryover)', async () => {
+    const goalFresh = createMockCategory({
+      id: 'c-goal-fresh', name: 'New Laptop', category_group_name: 'Savings',
+      goal_type: 'NEED',
+      // no carryover, just funded this month
+      budgeted: 3000000, activity: 0, balance: 3000000,
+    });
+    const goalCarry = createMockCategory({
+      id: 'c-goal-carry', name: 'Vacation', category_group_name: 'Savings',
+      goal_type: 'TB',
+      // prior_carryover = 1000
+      budgeted: 50000, activity: 0, balance: 1050000,
+    });
+    client.getBudgetMonth.mockResolvedValue(monthResponse([goalFresh, goalCarry]));
+
+    const result = await tool.execute({ budget_id: 'b1', month: '2024-01-01', skip_closed_cc_categories: false });
+
+    expect(client.updateCategoryBudget).not.toHaveBeenCalled();
+    expect(result.skipped.some(s => s.category_id === 'c-goal-fresh' && s.reason === 'goal')).toBe(true);
+    expect(result.skipped.some(s => s.category_id === 'c-goal-carry' && s.reason === 'goal')).toBe(true);
+  });
+
+  it('skips categories with non-positive balance (handled by other phases)', async () => {
+    const zero = createMockCategory({
+      id: 'c-zero', name: 'Zero', category_group_name: 'G', goal_type: null,
+      budgeted: 50000, activity: -50000, balance: 0,
+    });
+    const negative = createMockCategory({
+      id: 'c-neg', name: 'Underfunded', category_group_name: 'G', goal_type: null,
+      budgeted: 0, activity: -25000, balance: -25000,
+    });
+    client.getBudgetMonth.mockResolvedValue(monthResponse([zero, negative]));
+
+    const result = await tool.execute({ budget_id: 'b1', month: '2024-01-01', skip_closed_cc_categories: false });
+
+    expect(client.updateCategoryBudget).not.toHaveBeenCalled();
+    expect(result.categories_touched).toBe(0);
+  });
+
+  it('skips a category whose entire positive balance is prior carryover (no excess)', async () => {
+    // budgeted=0, activity=0, balance=1000 → carryover=1000, excess=0 → no change
+    const savedUp = createMockCategory({
+      id: 'c-saved', name: 'Saved', category_group_name: 'Misc', goal_type: null,
+      budgeted: 0, activity: 0, balance: 1000000,
+    });
+    client.getBudgetMonth.mockResolvedValue(monthResponse([savedUp]));
+
+    const result = await tool.execute({ budget_id: 'b1', month: '2024-01-01', skip_closed_cc_categories: false });
+
+    expect(client.updateCategoryBudget).not.toHaveBeenCalled();
+    expect(result.categories_touched).toBe(0);
+  });
+
+  it('skips Ready-to-Assign, hidden, deleted, and closed-CC payment categories', async () => {
+    const rta = createMockCategory({
+      id: 'c-rta', name: 'Inflow: Ready to Assign',
+      category_group_name: 'Internal Master Category',
+      goal_type: null, budgeted: 100000, activity: 0, balance: 100000,
+    });
+    const hidden = createMockCategory({
+      id: 'c-hidden', name: 'Hidden Stash', hidden: true,
+      category_group_name: 'Misc', goal_type: null,
+      budgeted: 200000, activity: 0, balance: 200000,
+    });
+    const deleted = createMockCategory({
+      id: 'c-del', name: 'Gone', deleted: true,
+      category_group_name: 'Misc', goal_type: null,
+      budgeted: 300000, activity: 0, balance: 300000,
+    });
+    const closedCc = createMockCategory({
+      id: 'c-cc', name: 'Closed Amex',
+      category_group_name: 'Credit Card Payments', goal_type: null,
+      budgeted: 400000, activity: 0, balance: 400000,
+    });
+    client.getBudgetMonth.mockResolvedValue(monthResponse([rta, hidden, deleted, closedCc]));
+    client.getAccounts.mockResolvedValue({
+      accounts: [{ name: 'Closed Amex', type: 'creditCard', closed: true }],
+      server_knowledge: 1,
+    });
+
+    const result = await tool.execute({ budget_id: 'b1', month: '2024-01-01' });
+
+    expect(client.updateCategoryBudget).not.toHaveBeenCalled();
+    expect(result.categories_touched).toBe(0);
+  });
+
+  it('honors include_categories', async () => {
+    const a = createMockCategory({
+      id: 'c-a', name: 'Alpha', category_group_name: 'G', goal_type: null,
+      budgeted: 100000, activity: 0, balance: 100000,
+    });
+    const b = createMockCategory({
+      id: 'c-b', name: 'Beta', category_group_name: 'G', goal_type: null,
+      budgeted: 200000, activity: 0, balance: 200000,
+    });
+    client.getBudgetMonth.mockResolvedValue(monthResponse([a, b]));
+
+    await tool.execute({
+      budget_id: 'b1', month: '2024-01-01', skip_closed_cc_categories: false,
+      include_categories: ['Alpha'],
+    });
+
+    expect(client.updateCategoryBudget).toHaveBeenCalledTimes(1);
+    expect(client.updateCategoryBudget).toHaveBeenCalledWith('b1', 'c-a', '2024-01-01', 0);
+  });
+
+  it('honors exclude_categories', async () => {
+    const a = createMockCategory({
+      id: 'c-a', name: 'Alpha', category_group_name: 'G', goal_type: null,
+      budgeted: 100000, activity: 0, balance: 100000,
+    });
+    const b = createMockCategory({
+      id: 'c-b', name: 'Beta', category_group_name: 'G', goal_type: null,
+      budgeted: 200000, activity: 0, balance: 200000,
+    });
+    client.getBudgetMonth.mockResolvedValue(monthResponse([a, b]));
+
+    await tool.execute({
+      budget_id: 'b1', month: '2024-01-01', skip_closed_cc_categories: false,
+      exclude_categories: ['Alpha'],
+    });
+
+    expect(client.updateCategoryBudget).toHaveBeenCalledTimes(1);
+    expect(client.updateCategoryBudget).toHaveBeenCalledWith('b1', 'c-b', '2024-01-01', 0);
+  });
+
+  it('dry_run plans without PATCHing', async () => {
+    const other = createMockCategory({
+      id: 'c-other', name: 'Other', category_group_name: 'Misc', goal_type: null,
+      budgeted: 7584000, activity: -28000, balance: 7556000,
+    });
+    client.getBudgetMonth.mockResolvedValue(monthResponse([other]));
+
+    const result = await tool.execute({
+      budget_id: 'b1', month: '2024-01-01', dry_run: true, skip_closed_cc_categories: false,
+    });
+
+    expect(client.updateCategoryBudget).not.toHaveBeenCalled();
+    expect(result.dry_run).toBe(true);
+    expect(result.details[0]!.status).toBe('planned');
+    expect(result.details[0]!.new_budgeted).toBe(28000);
+    expect(result.details[0]!.delta).toBe(-7556000);
+  });
+
+  it('wraps errors exactly once (no double-wrap)', async () => {
+    client.getBudgetMonth.mockRejectedValue(new Error('boom'));
+    try {
+      await tool.execute({ budget_id: 'b1', month: '2024-01-01', skip_closed_cc_categories: false });
+      expect.fail('expected error');
+    } catch (e) {
+      const msg = (e as Error).message;
+      const occurrences = (msg.match(/auto-reduce overfunded failed/g) ?? []).length;
+      expect(occurrences).toBe(1);
+    }
+  });
+});

--- a/tests/tools/budgeting/categoryFilters.test.ts
+++ b/tests/tools/budgeting/categoryFilters.test.ts
@@ -166,6 +166,42 @@ describe('filterCategories', () => {
     });
   });
 
+  describe('skip_goals (reduce-overfunded style)', () => {
+    it('skips every category with a goal regardless of carryover', () => {
+      const goalWithCarryover = createMockCategory({
+        id: 'c-goal-carry', name: 'Vacation', goal_type: 'TB',
+        // prior_carryover = 100
+        budgeted: 50000, activity: 0, balance: 150000,
+      });
+      const goalNoCarryover = createMockCategory({
+        id: 'c-goal-fresh', name: 'New Laptop', goal_type: 'NEED',
+        // prior_carryover = 0
+        budgeted: 50000, activity: 0, balance: 50000,
+      });
+      const noGoal = createMockCategory({
+        id: 'c-plain', name: 'Other', goal_type: null,
+        budgeted: 100000, activity: 0, balance: 100000,
+      });
+      const { kept, skipped } = filterCategories(
+        [goalWithCarryover, goalNoCarryover, noGoal],
+        { skip_goals: true }
+      );
+      expect(kept.map(c => c.id)).toEqual(['c-plain']);
+      const byId = Object.fromEntries(skipped.map(s => [s.category_id, s.reason]));
+      expect(byId['c-goal-carry']).toBe('goal');
+      expect(byId['c-goal-fresh']).toBe('goal');
+    });
+
+    it('is disabled by default', () => {
+      const goalCat = createMockCategory({
+        id: 'c-goal', name: 'Vacation', goal_type: 'TB',
+        budgeted: 50000, activity: 0, balance: 50000,
+      });
+      const { kept } = filterCategories([goalCat]);
+      expect(kept).toHaveLength(1);
+    });
+  });
+
   it('include takes precedence: categories not in include are dropped even if otherwise kept', () => {
     const { kept, skipped } = filterCategories(cats(), { include: ['c-food'] });
     expect(kept.map(c => c.id)).toEqual(['c-food']);


### PR DESCRIPTION
Closes #22.

## Summary
- Adds `ynab_auto_reduce_overfunded` — frees the portion of any positive balance that sits above prior-month carryover (issue #22 repro: `Other` budgeted $7,584 / activity $28 → reduced to $28, $7,556 returned to RTA).
- Wires it into `ynab_auto_balance_month` as a new middle phase: `sweep_positives → reduce_overfunded → assign_underfunded`. Phase is on by default; pass `reduce_overfunded:false` to restore the original two-phase behavior.
- Skips every goal-bearing category (`skip_goals` filter — distinct from the existing `skip_goal_carryover` which only skips goals with positive carryover) so this never claws back goal funding, even mid-funding.
- Reuses one `getAccounts` call across all three phases (rate-limit budget unchanged).

## Test plan
- [x] `npm test` — 474 passed, 2 skipped
- [x] `npm run lint` (`tsc --noEmit`) clean
- [x] `npm run build` clean
- [x] New tests cover: issue #22 repro, carryover preservation, goal categories (with and without carryover), zero/negative balance skips, RTA/hidden/deleted/closed-CC skips, include/exclude lists, dry-run, error wrapping
- [x] Existing `auto_balance_month` tests updated for three-phase flow + new `reduce_overfunded:false` opt-out test
- [ ] Manual MCP run against a real budget: dry-run → live → re-run (should be no-op the third time)

## Versioning
Minor bump (`1.5.0 → 1.6.0`): new tool, new optional parameter, new entry in `phases[]`. Inner `BudgetingResult` shape unchanged.