### PR TITLE
feat(categories)!: trim get-categories payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ This server provides **30+ specialized tools** organized into these categories:
 ### Budget & Account Management (3 tools)
 - `ynab_list_budgets` - Get all accessible budgets with metadata
 - `ynab_get_accounts` - Retrieve account details, balances, and settings
-- `ynab_get_budget_month` - Get monthly budget data with category allocations
+- `ynab_get_budget_month` - Get monthly budget data (trimmed by default; use `category_filter: 'all'` for full list)
 
 ### Transaction Management (12 tools)
 - `ynab_get_transactions` - Query transactions with advanced filtering
@@ -106,9 +106,18 @@ This server provides **30+ specialized tools** organized into these categories:
 - `ynab_unlink_transfer` - Remove transfer links
 
 ### Category & Budget Management (3 tools)
-- `ynab_get_categories` - Get category groups and individual categories
+- `ynab_get_categories` - Get category groups and individual categories (trimmed by default; use `category_filter: 'all'` for full list)
 - `ynab_get_category` - Get detailed category information
 - `ynab_update_category_budget` - Adjust category budget allocations
+
+### Budgeting Automation (7 tools)
+- `ynab_auto_sweep_positives` - Sweep positive activity (refunds, interest) back to Ready-to-Assign
+- `ynab_auto_reduce_overfunded` - Free money stuck in over-funded categories (preserves carryover, skips goals)
+- `ynab_auto_assign_underfunded` - Fund every negative-balance category to exactly $0
+- `ynab_auto_balance_month` - Sweep → reduce → assign, composed in one call with `dry_run` support
+- `ynab_assign_same_as_last_month` - Copy previous month's budgeted amounts
+- `ynab_assign_average_spend` - Assign rolling average of recent outflow per category
+- `ynab_reset_available_amounts` - Set every category's balance to $0 for the month
 
 ### Payee Management (3 tools)
 - `ynab_get_payees` - List all payees with metadata

--- a/docs/TOOL_REFERENCE.md
+++ b/docs/TOOL_REFERENCE.md
@@ -183,7 +183,7 @@ Get budget data for a specific month. Response is trimmed by default to keep pay
 ```
 
 **Notes:**
-- Goal fields (`goal_type`, `goal_target`, `goal_percentage_complete`, etc.) are never returned. Use `ynab_get_categories` / `ynab_get_category` when goal metadata is needed.
+- Goal fields (`goal_type`, `goal_target`, `goal_percentage_complete`, etc.) are never returned. Use `ynab_get_category` when goal metadata is needed for a specific category.
 - `deleted` categories are always excluded, regardless of `category_filter`.
 - Default `'active'` is tuned for the common "show me what's happening this month" use. Use `'all'` for full dumps or diffing against external data.
 
@@ -634,6 +634,7 @@ Get category groups and categories for a budget. Response is trimmed by default 
 - `deleted` groups and categories are always excluded, regardless of `category_filter`.
 - Groups with zero matching categories after filtering are omitted from the response.
 - Default `'active'` is tuned for the common "show me what's configured" use. Use `'all'` for full dumps or diffing against external data.
+- **Delta sync safety:** When `last_knowledge_of_server` is set and `category_filter` is omitted, the filter is forced to `'all'`. Under delta sync, any filter that rejects zero-valued categories would silently drop categories that just changed to zero — the caller would then advance `server_knowledge` past those changes and never see them. Pass an explicit `category_filter` to override this if you've accepted the risk.
 
 ---
 

--- a/docs/TOOL_REFERENCE.md
+++ b/docs/TOOL_REFERENCE.md
@@ -7,6 +7,7 @@ This document provides comprehensive documentation for all 30+ tools available i
 - [Budget & Account Management](#budget--account-management)
 - [Transaction Management](#transaction-management)
 - [Category & Budget Management](#category--budget-management)
+- [Budgeting Automation](#budgeting-automation)
 - [Payee Management](#payee-management)
 - [Scheduled Transactions](#scheduled-transactions)
 - [Transfer Management](#transfer-management)
@@ -139,14 +140,18 @@ Get all accounts for a specific budget with detailed balance information.
 
 ### `ynab_get_budget_month`
 
-Get detailed monthly budget data for a specific month.
+Get budget data for a specific month. Response is trimmed by default to keep payloads small: only active categories are included, goal metadata and deleted categories are always omitted.
 
 **Parameters:**
 ```typescript
 {
-  budget_id: string;        // Required: Budget ID
-  month: string;            // Required: Month in YYYY-MM-DD format (first day of month)
-  include_categories?: boolean;  // Include detailed category data
+  budget_id: string;          // Required: Budget ID
+  month: string;              // Required: YYYY-MM-01 (first day of month)
+  category_filter?:           // Default: 'active'
+    | 'active'          // budgeted/activity/balance non-zero
+    | 'with_activity'   // activity non-zero
+    | 'with_balance'    // balance non-zero
+    | 'all';            // every non-deleted category (including zero-balance)
 }
 ```
 
@@ -155,42 +160,39 @@ Get detailed monthly budget data for a specific month.
 {
   month: {
     month: string;
-    note: string | null;
-    income: number;           // Total income in milliunits
-    budgeted: number;         // Total budgeted in milliunits
-    activity: number;         // Total activity in milliunits
-    to_be_budgeted: number;   // Available to budget in milliunits
+    income: { milliunits: number; formatted: string };
+    budgeted: { milliunits: number; formatted: string };
+    activity: { milliunits: number; formatted: string };
+    to_be_budgeted: { milliunits: number; formatted: string };
     age_of_money: number | null;
-    deleted: boolean;
-    categories?: Array<{
+    note?: string;            // Only present when non-empty
+    categories: Array<{
       id: string;
+      category_group_id: string;
+      category_group_name: string;
       name: string;
-      budgeted: number;       // Budgeted amount in milliunits
-      activity: number;       // Actual spending in milliunits
-      balance: number;        // Category balance in milliunits
-      goal_type: string | null;
-      goal_day: number | null;
-      goal_cadence: number | null;
-      goal_cadence_frequency: number | null;
-      goal_creation_month: string | null;
-      goal_target: number | null;
-      goal_target_month: string | null;
-      goal_percentage_complete: number | null;
-      goal_months_to_budget: number | null;
-      goal_under_funded: number | null;
-      goal_overall_funded: number | null;
-      goal_overall_left: number | null;
+      hidden: boolean;
+      budgeted: { milliunits: number; formatted: string };
+      activity: { milliunits: number; formatted: string };
+      balance: { milliunits: number; formatted: string };
+      note?: string;          // Only present when non-empty
     }>;
   };
+  server_knowledge: number;
 }
 ```
+
+**Notes:**
+- Goal fields (`goal_type`, `goal_target`, `goal_percentage_complete`, etc.) are never returned. Use `ynab_get_categories` / `ynab_get_category` when goal metadata is needed.
+- `deleted` categories are always excluded, regardless of `category_filter`.
+- Default `'active'` is tuned for the common "show me what's happening this month" use. Use `'all'` for full dumps or diffing against external data.
 
 **Example:**
 ```json
 {
   "budget_id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
   "month": "2024-01-01",
-  "include_categories": true
+  "category_filter": "active"
 }
 ```
 
@@ -589,15 +591,18 @@ Update the splits of an existing split transaction.
 
 ### `ynab_get_categories`
 
-Get all category groups and categories for a budget.
+Get category groups and categories for a budget. Response is trimmed by default to keep payloads small: only active categories are included, goal metadata and deleted groups/categories are always omitted, and empty groups are dropped.
 
 **Parameters:**
 ```typescript
 {
   budget_id: string;                    // Required: Budget ID
-  last_knowledge_of_server?: number;   // For delta sync
-  include_hidden?: boolean;             // Include hidden categories (default: false)
-  include_deleted?: boolean;            // Include deleted categories (default: false)
+  category_filter?:                     // Default: 'active'
+    | 'active'          // budgeted/activity/balance non-zero
+    | 'with_activity'   // activity non-zero
+    | 'with_balance'    // balance non-zero
+    | 'all';            // every non-deleted category (including zero-balance)
+  last_knowledge_of_server?: number;    // For delta sync
 }
 ```
 
@@ -608,41 +613,27 @@ Get all category groups and categories for a budget.
     id: string;
     name: string;
     hidden: boolean;
-    deleted: boolean;
     categories: Array<{
       id: string;
+      category_group_id: string;
+      category_group_name: string;
       name: string;
       hidden: boolean;
-      original_category_group_id: string | null;
-      note: string | null;
-      budgeted: number;                 // Current month budgeted amount
-      activity: number;                 // Current month activity
-      balance: number;                  // Current balance
-      goal_type: 'TB' | 'TBD' | 'MF' | 'NEED' | 'DEBT' | null;
-      goal_day: number | null;
-      goal_cadence: number | null;
-      goal_cadence_frequency: number | null;
-      goal_creation_month: string | null;
-      goal_target: number | null;
-      goal_target_month: string | null;
-      goal_percentage_complete: number | null;
-      goal_months_to_budget: number | null;
-      goal_under_funded: number | null;
-      goal_overall_funded: number | null;
-      goal_overall_left: number | null;
-      deleted: boolean;
+      budgeted: { milliunits: number; formatted: string };  // Current month
+      activity: { milliunits: number; formatted: string };  // Current month
+      balance: { milliunits: number; formatted: string };   // Current balance
+      note?: string;                                        // Only present when non-empty
     }>;
   }>;
   server_knowledge: number;
 }
 ```
 
-**Goal Types:**
-- `TB` - Target Balance
-- `TBD` - Target Balance by Date
-- `MF` - Monthly Funding
-- `NEED` - Plan Your Spending
-- `DEBT` - Debt Payoff
+**Notes:**
+- Goal fields (`goal_type`, `goal_target`, `goal_percentage_complete`, etc.) are never returned. Use `ynab_get_category` when goal metadata is needed for a specific category.
+- `deleted` groups and categories are always excluded, regardless of `category_filter`.
+- Groups with zero matching categories after filtering are omitted from the response.
+- Default `'active'` is tuned for the common "show me what's configured" use. Use `'all'` for full dumps or diffing against external data.
 
 ---
 
@@ -761,6 +752,119 @@ Update the budgeted amount for a category in a specific month.
   };
 }
 ```
+
+---
+
+## Budgeting Automation
+
+Tools that mutate `budgeted` amounts across many categories in one call. All seven share a common input schema and response shape; the per-tool sections below document only what's distinctive.
+
+### Shared input
+
+```typescript
+interface BaseBudgetingInput {
+  budget_id: string;                      // Required
+  month: string;                          // Required: YYYY-MM-01
+  include_categories?: string[];          // Restrict to these (by id or case-insensitive name)
+  exclude_categories?: string[];          // Skip these (by id or case-insensitive name)
+  skip_closed_cc_categories?: boolean;    // Default: true
+  skip_hidden?: boolean;                  // Default: true
+  dry_run?: boolean;                      // Default: false — plan without PATCHing
+}
+```
+
+### Shared response (`BudgetingResult`)
+
+```typescript
+{
+  phase: string;                          // Tool-specific identifier
+  dry_run: boolean;
+  categories_touched: number;
+  total_moved_milliunits: number;
+  to_be_budgeted_before: { milliunits: number; formatted: string };
+  to_be_budgeted_after: { milliunits: number; formatted: string } | null;  // null on dry_run
+  skipped_count: number;
+  skipped_by_reason: Record<string, number>;  // e.g. { hidden: 36, ready_to_assign: 3 }
+  details: Array<{
+    category_id: string;
+    category_name: string;
+    previous_budgeted: number;
+    new_budgeted: number;
+    delta: number;
+    status: 'applied' | 'planned' | 'skipped_noop' | 'failed';
+    error?: string;
+  }>;
+  failed: Array<{ category_id: string; category_name: string; error: string }>;
+}
+```
+
+**Skip reasons** (`skipped_by_reason` keys): `excluded`, `not_included`, `hidden`, `deleted`, `ready_to_assign`, `closed_cc`, `goal_carryover`, `goal`, `no_prior_month` (assign-same-as-last-month only), `no_history` (assign-average-spend only).
+
+### `ynab_auto_sweep_positives`
+
+Sweeps positive activity (refunds, reimbursements, interest) back to Ready-to-Assign by reducing `budgeted` by `activity`. Preserves savings: categories with a goal *and* a positive prior-month carryover are skipped (`skipped_by_reason.goal_carryover`).
+
+**Parameters:** `BaseBudgetingInput` (no extras). **Phase:** `sweep_positives`.
+
+### `ynab_auto_reduce_overfunded`
+
+Frees money stuck in over-funded categories — the counterpart to sweep. Reduces `budgeted` so excess above prior-month carryover returns to Ready-to-Assign. Never drives `budgeted` below zero. Skips *every* category with a goal (`skipped_by_reason.goal`).
+
+**Parameters:** `BaseBudgetingInput` (no extras). **Phase:** `reduce_overfunded`.
+
+### `ynab_auto_assign_underfunded`
+
+Mirrors YNAB's "Auto-Assign: Underfunded" button. Funds every category with a negative month-balance to exactly $0.
+
+**Parameters:** `BaseBudgetingInput` (no extras). **Phase:** `assign_underfunded`.
+
+### `ynab_auto_balance_month`
+
+Composes sweep-positives → reduce-overfunded → assign-underfunded in one call. Loads accounts + month once; reuses the account list across phases (saves rate-limit budget).
+
+**Parameters:**
+```typescript
+BaseBudgetingInput & {
+  reduce_overfunded?: boolean;   // Default: true. Set false to skip the middle phase.
+}
+```
+
+**Response:** different from the shared shape — aggregates sub-phase results.
+```typescript
+{
+  phase: 'balance_month';
+  dry_run: boolean;
+  phases: BudgetingResult[];     // Sweep, (reduce), assign in order
+  total_moved_milliunits: number;
+}
+```
+
+**Note:** in `dry_run`, each phase's planned changes are simulated forward so the same category doesn't appear in multiple phases' details.
+
+### `ynab_assign_same_as_last_month`
+
+For each filtered category, copies the previous month's `budgeted` amount. Categories absent from the prior month are skipped (`skipped_by_reason.no_prior_month`).
+
+**Parameters:** `BaseBudgetingInput` (no extras). **Phase:** `assign_same_as_last_month`.
+
+### `ynab_assign_average_spend`
+
+Assigns each category an amount equal to its rolling average *outflow* over recent months. Positive activity (refunds) is ignored so the average reflects real spending. Categories with no outflow history in the window are skipped (`skipped_by_reason.no_history`).
+
+**Parameters:**
+```typescript
+BaseBudgetingInput & {
+  lookback_months?: number;   // Default: 3, range 1–12
+}
+```
+
+**Response:** `BudgetingResult` plus `lookback_used: number` (the actual max window observed; may be less than requested if a category is newer than `lookback_months`). **Phase:** `assign_average_spend`.
+
+### `ynab_reset_available_amounts`
+
+Mirrors YNAB's "Reset Available Amounts": sets every filtered category's balance to exactly $0 for the month by adjusting `budgeted` by `-balance`. Positive balances flow back to Ready-to-Assign; negative balances are covered from it.
+
+**Parameters:** `BaseBudgetingInput` (no extras). **Phase:** `reset_available_amounts`.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ynab-mcp-server",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Comprehensive Model Context Protocol server providing intelligent access to YNAB (You Need A Budget) data with AI-powered budget recommendations, spending analysis, and complete transaction management",
   "type": "module",
   "main": "dist/index.js",

--- a/src/tools/categories/getCategories.ts
+++ b/src/tools/categories/getCategories.ts
@@ -7,10 +7,10 @@ type CategoryFilter = z.infer<typeof CategoryFilterSchema>;
 
 const GetCategoriesInputSchema = z.object({
   budget_id: z.string().describe('The ID of the budget to get categories for'),
-  category_filter: CategoryFilterSchema.optional().default('active').describe(
-    'Which categories to include. "active" (default): budgeted/activity/balance non-zero. "with_activity": activity non-zero. "with_balance": balance non-zero. "all": every non-deleted category (including zero-balance). Deleted categories/groups and goal metadata are always omitted.'
+  category_filter: CategoryFilterSchema.optional().describe(
+    'Which categories to include. "active" (default): budgeted/activity/balance non-zero. "with_activity": activity non-zero. "with_balance": balance non-zero. "all": every non-deleted category (including zero-balance). When last_knowledge_of_server is set and category_filter is omitted, "all" is used instead of "active" to prevent silent data loss on categories that changed to zero. Deleted categories/groups and goal metadata are always omitted.'
   ),
-  last_knowledge_of_server: z.number().optional().describe('Server knowledge for delta sync - only return data modified since this value'),
+  last_knowledge_of_server: z.number().optional().describe('Server knowledge for delta sync - only return data modified since this value. With delta sync, any filtering is applied AFTER the delta fetch, so a category that changed to all-zero values would be silently dropped by the default "active" filter. When this is set and no explicit category_filter is passed, the filter is forced to "all" to preserve delta fidelity.'),
 });
 
 type GetCategoriesInput = z.infer<typeof GetCategoriesInputSchema>;
@@ -71,6 +71,13 @@ export class GetCategoriesTool extends YnabTool {
   }> {
     const input = this.validateArgs<GetCategoriesInput>(args);
 
+    // Under delta sync, any filter that rejects zero-valued categories would silently drop
+    // categories that just changed to zero — the caller would advance server_knowledge past
+    // the change and never see it. Default to "all" in that case so incremental consumers
+    // stay consistent. Explicit category_filter is honored for callers who opt into the risk.
+    const filter: CategoryFilter =
+      input.category_filter ?? (input.last_knowledge_of_server !== undefined ? 'all' : 'active');
+
     try {
       const requestOptions = {
         ...(input.last_knowledge_of_server !== undefined && {
@@ -89,7 +96,7 @@ export class GetCategoriesTool extends YnabTool {
 
         const categories: ProcessedCategory[] = [];
         for (const category of group.categories) {
-          if (!shouldInclude(category, input.category_filter)) continue;
+          if (!shouldInclude(category, filter)) continue;
 
           const processed: ProcessedCategory = {
             id: category.id,

--- a/src/tools/categories/getCategories.ts
+++ b/src/tools/categories/getCategories.ts
@@ -1,100 +1,80 @@
 import { z } from 'zod';
 import { YnabTool } from '../base.js';
-import type { YnabCategoriesResponse } from '../../types/index.js';
+import type { YnabCategoriesResponse, YnabCategory } from '../../types/index.js';
 
-/**
- * Input schema for the get categories tool
- */
+const CategoryFilterSchema = z.enum(['active', 'with_activity', 'with_balance', 'all']);
+type CategoryFilter = z.infer<typeof CategoryFilterSchema>;
+
 const GetCategoriesInputSchema = z.object({
   budget_id: z.string().describe('The ID of the budget to get categories for'),
+  category_filter: CategoryFilterSchema.optional().default('active').describe(
+    'Which categories to include. "active" (default): budgeted/activity/balance non-zero. "with_activity": activity non-zero. "with_balance": balance non-zero. "all": every non-deleted category (including zero-balance). Deleted categories/groups and goal metadata are always omitted.'
+  ),
   last_knowledge_of_server: z.number().optional().describe('Server knowledge for delta sync - only return data modified since this value'),
 });
 
 type GetCategoriesInput = z.infer<typeof GetCategoriesInputSchema>;
 
+interface FormattedAmount {
+  milliunits: number;
+  formatted: string;
+}
+
+interface ProcessedCategory {
+  id: string;
+  category_group_id: string;
+  category_group_name: string;
+  name: string;
+  hidden: boolean;
+  budgeted: FormattedAmount;
+  activity: FormattedAmount;
+  balance: FormattedAmount;
+  note?: string;
+}
+
+interface ProcessedCategoryGroup {
+  id: string;
+  name: string;
+  hidden: boolean;
+  categories: ProcessedCategory[];
+}
+
+function shouldInclude(c: YnabCategory, filter: CategoryFilter): boolean {
+  if (c.deleted) return false;
+  switch (filter) {
+    case 'all':
+      return true;
+    case 'with_activity':
+      return c.activity !== 0;
+    case 'with_balance':
+      return c.balance !== 0;
+    case 'active':
+      return c.budgeted !== 0 || c.activity !== 0 || c.balance !== 0;
+  }
+}
+
 /**
  * Tool for getting all categories and category groups for a budget
- * 
- * This tool retrieves category information including:
- * - Category group hierarchies
- * - Individual category details
- * - Budgeted amounts, activity, and balance
- * - Goal information (target amounts, dates, etc.)
- * - Hidden categories and groups
- * - Delta sync support for efficient updates
+ *
+ * Returns only active categories by default (budgeted/activity/balance non-zero)
+ * and omits goal metadata + deleted groups/categories to keep payload small.
+ * Use category_filter to broaden or narrow the result.
  */
 export class GetCategoriesTool extends YnabTool {
   name = 'ynab_get_categories';
-  description = 'Get all categories and category groups for a budget. Includes budgeted amounts, activity, balance, and goal information. Supports delta sync for efficient updates.';
+  description = 'Get categories and category groups for a budget. Returns only active categories by default (budgeted/activity/balance non-zero) and omits goal metadata and deleted groups/categories. Use category_filter to broaden or narrow the result. Supports delta sync.';
   inputSchema = GetCategoriesInputSchema;
 
-  /**
-   * Execute the get categories tool
-   * 
-   * @param args Input arguments including budget_id and optional delta sync
-   * @returns Category groups and categories with comprehensive metadata
-   */
   async execute(args: unknown): Promise<{
-    category_groups: Array<{
-      id: string;
-      name: string;
-      hidden: boolean;
-      deleted: boolean;
-      categories: Array<{
-        id: string;
-        category_group_id: string;
-        category_group_name: string;
-        name: string;
-        hidden: boolean;
-        original_category_group_id: string | null;
-        note: string | null;
-        budgeted: {
-          milliunits: number;
-          formatted: string;
-        };
-        activity: {
-          milliunits: number;
-          formatted: string;
-        };
-        balance: {
-          milliunits: number;
-          formatted: string;
-        };
-        goal_type: string | null;
-        goal_day: number | null;
-        goal_cadence: number | null;
-        goal_cadence_frequency: number | null;
-        goal_creation_month: string | null;
-        goal_target: {
-          milliunits: number;
-          formatted: string;
-        } | null;
-        goal_target_month: string | null;
-        goal_percentage_complete: number | null;
-        goal_months_to_budget: number | null;
-        goal_under_funded: {
-          milliunits: number;
-          formatted: string;
-        } | null;
-        goal_overall_funded: {
-          milliunits: number;
-          formatted: string;
-        } | null;
-        goal_overall_left: {
-          milliunits: number;
-          formatted: string;
-        } | null;
-        deleted: boolean;
-      }>;
-    }>;
+    category_groups: ProcessedCategoryGroup[];
     server_knowledge: number;
   }> {
     const input = this.validateArgs<GetCategoriesInput>(args);
 
     try {
       const requestOptions = {
-        ...(input.last_knowledge_of_server !== undefined && { 
-          lastKnowledgeOfServer: input.last_knowledge_of_server 
+        ...(input.last_knowledge_of_server !== undefined && {
+          lastKnowledgeOfServer: input.last_knowledge_of_server,
         }),
       };
 
@@ -103,65 +83,53 @@ export class GetCategoriesTool extends YnabTool {
         requestOptions
       );
 
-      // Process and format category data
-      const processedCategoryGroups = categoriesResponse.category_groups.map(group => ({
-        id: group.id,
-        name: group.name,
-        hidden: group.hidden,
-        deleted: group.deleted,
-        categories: group.categories.map(category => ({
-          id: category.id,
-          category_group_id: category.category_group_id,
-          category_group_name: group.name,
-          name: category.name,
-          hidden: category.hidden,
-          original_category_group_id: category.original_category_group_id,
-          note: category.note,
-          budgeted: {
-            milliunits: category.budgeted,
-            formatted: this.formatCurrency(category.budgeted),
-          },
-          activity: {
-            milliunits: category.activity,
-            formatted: this.formatCurrency(category.activity),
-          },
-          balance: {
-            milliunits: category.balance,
-            formatted: this.formatCurrency(category.balance),
-          },
-          goal_type: category.goal_type,
-          goal_day: category.goal_day,
-          goal_cadence: category.goal_cadence,
-          goal_cadence_frequency: category.goal_cadence_frequency,
-          goal_creation_month: category.goal_creation_month,
-          goal_target: category.goal_target ? {
-            milliunits: category.goal_target,
-            formatted: this.formatCurrency(category.goal_target),
-          } : null,
-          goal_target_month: category.goal_target_month,
-          goal_percentage_complete: category.goal_percentage_complete,
-          goal_months_to_budget: category.goal_months_to_budget,
-          goal_under_funded: category.goal_under_funded ? {
-            milliunits: category.goal_under_funded,
-            formatted: this.formatCurrency(category.goal_under_funded),
-          } : null,
-          goal_overall_funded: category.goal_overall_funded ? {
-            milliunits: category.goal_overall_funded,
-            formatted: this.formatCurrency(category.goal_overall_funded),
-          } : null,
-          goal_overall_left: category.goal_overall_left ? {
-            milliunits: category.goal_overall_left,
-            formatted: this.formatCurrency(category.goal_overall_left),
-          } : null,
-          deleted: category.deleted,
-        })),
-      }));
+      const processedCategoryGroups: ProcessedCategoryGroup[] = [];
+      for (const group of categoriesResponse.category_groups) {
+        if (group.deleted) continue;
+
+        const categories: ProcessedCategory[] = [];
+        for (const category of group.categories) {
+          if (!shouldInclude(category, input.category_filter)) continue;
+
+          const processed: ProcessedCategory = {
+            id: category.id,
+            category_group_id: category.category_group_id,
+            category_group_name: group.name,
+            name: category.name,
+            hidden: category.hidden,
+            budgeted: {
+              milliunits: category.budgeted,
+              formatted: this.formatCurrency(category.budgeted),
+            },
+            activity: {
+              milliunits: category.activity,
+              formatted: this.formatCurrency(category.activity),
+            },
+            balance: {
+              milliunits: category.balance,
+              formatted: this.formatCurrency(category.balance),
+            },
+          };
+
+          if (category.note) processed.note = category.note;
+
+          categories.push(processed);
+        }
+
+        if (categories.length === 0) continue;
+
+        processedCategoryGroups.push({
+          id: group.id,
+          name: group.name,
+          hidden: group.hidden,
+          categories,
+        });
+      }
 
       return {
         category_groups: processedCategoryGroups,
         server_knowledge: categoriesResponse.server_knowledge,
       };
-
     } catch (error) {
       this.handleError(error, 'get categories');
     }

--- a/tests/tools/categories/getCategories.test.ts
+++ b/tests/tools/categories/getCategories.test.ts
@@ -244,6 +244,67 @@ describe('GetCategoriesTool', () => {
       }
     });
   });
+
+  describe('delta sync safety', () => {
+    it('forces category_filter to "all" when last_knowledge_of_server is set (prevents silent data loss)', async () => {
+      // A category that changed to zero would be in the delta but dropped by the active filter,
+      // causing silent drift for incremental-sync consumers.
+      const zeroed = createMockCategory({ id: 'zeroed', name: 'Zeroed', budgeted: 0, activity: 0, balance: 0 });
+      const group = createMockCategoryGroup(0, { id: 'g1', name: 'G' });
+      group.categories = [zeroed];
+      client.getCategories.mockResolvedValue({ category_groups: [group], server_knowledge: 200 });
+
+      const result = await tool.execute({
+        budget_id: 'b',
+        last_knowledge_of_server: 100,
+        // category_filter defaults to 'active' but should be overridden to 'all' under delta sync
+      });
+
+      expect(result.category_groups).toHaveLength(1);
+      expect(result.category_groups[0]!.categories).toHaveLength(1);
+      expect(result.category_groups[0]!.categories[0]!.id).toBe('zeroed');
+    });
+
+    it('does not drop deleted categories when forcing all filter under delta sync', async () => {
+      // Even under delta sync, deleted categories should still be excluded —
+      // they're communicated via the top-level deleted flag on the original response,
+      // but the processed output already strips that. So dropping them is fine;
+      // what matters is that non-deleted-zero changes survive.
+      const live = createMockCategory({ id: 'live', name: 'Live', budgeted: 0, activity: 0, balance: 0, deleted: false });
+      const gone = createMockCategory({ id: 'gone', name: 'Gone', budgeted: 0, activity: 0, balance: 0, deleted: true });
+      const group = createMockCategoryGroup(0, { id: 'g1', name: 'G' });
+      group.categories = [live, gone];
+      client.getCategories.mockResolvedValue({ category_groups: [group], server_knowledge: 300 });
+
+      const result = await tool.execute({
+        budget_id: 'b',
+        last_knowledge_of_server: 200,
+      });
+
+      const ids = result.category_groups[0]!.categories.map(c => c.id);
+      expect(ids).toContain('live');
+      expect(ids).not.toContain('gone');
+    });
+
+    it('respects explicit category_filter even with delta sync (user opt-out)', async () => {
+      // If caller explicitly asks for 'active' with delta sync, they've read the docs
+      // and accepted the risk — we respect their choice.
+      const zeroed = createMockCategory({ id: 'zeroed', name: 'Zeroed', budgeted: 0, activity: 0, balance: 0 });
+      const active = createMockCategory({ id: 'active', name: 'Active', budgeted: 100000, activity: 0, balance: 100000 });
+      const group = createMockCategoryGroup(0, { id: 'g1', name: 'G' });
+      group.categories = [zeroed, active];
+      client.getCategories.mockResolvedValue({ category_groups: [group], server_knowledge: 200 });
+
+      const result = await tool.execute({
+        budget_id: 'b',
+        last_knowledge_of_server: 100,
+        category_filter: 'active',
+      });
+
+      const ids = result.category_groups[0]!.categories.map(c => c.id);
+      expect(ids).toEqual(['active']);
+    });
+  });
 });
 
 describe('GetCategoryTool', () => {

--- a/tests/tools/categories/getCategories.test.ts
+++ b/tests/tools/categories/getCategories.test.ts
@@ -58,6 +58,192 @@ describe('GetCategoriesTool', () => {
     client.getCategories.mockRejectedValue(new Error('API error'));
     await expect(tool.execute({ budget_id: 'test-budget' })).rejects.toThrow();
   });
+
+  describe('response trimming', () => {
+    function setupWithCategories(cats: any[], groupOverrides: any = {}) {
+      const group = createMockCategoryGroup(0, { id: 'g1', name: 'G', ...groupOverrides });
+      group.categories = cats;
+      client.getCategories.mockResolvedValue({ category_groups: [group], server_knowledge: 1 });
+    }
+
+    it('filters zero-only categories by default (active filter)', async () => {
+      setupWithCategories([
+        createMockCategory({ id: 'active', name: 'Active', budgeted: 100000, activity: -50000, balance: 50000 }),
+        createMockCategory({ id: 'zero', name: 'Zero', budgeted: 0, activity: 0, balance: 0 }),
+      ]);
+
+      const result = await tool.execute({ budget_id: 'test-budget' });
+
+      expect(result.category_groups).toHaveLength(1);
+      expect(result.category_groups[0]!.categories).toHaveLength(1);
+      expect(result.category_groups[0]!.categories[0]!.id).toBe('active');
+    });
+
+    it('drops goal_* fields, original_category_group_id, and deleted from categories', async () => {
+      setupWithCategories([
+        createMockCategory({
+          id: 'cat-1',
+          name: 'G',
+          budgeted: 100000,
+          activity: -10000,
+          balance: 90000,
+          goal_type: 'TB',
+          goal_target: 500000,
+          goal_percentage_complete: 18,
+          original_category_group_id: 'old-group',
+        }),
+      ]);
+
+      const result = await tool.execute({ budget_id: 'test-budget' });
+      const cat = result.category_groups[0]!.categories[0] as Record<string, unknown>;
+
+      for (const key of Object.keys(cat)) {
+        expect(key.startsWith('goal_')).toBe(false);
+      }
+      expect(cat.original_category_group_id).toBeUndefined();
+      expect(cat.deleted).toBeUndefined();
+    });
+
+    it('drops deleted field from category groups', async () => {
+      setupWithCategories([
+        createMockCategory({ id: 'c', name: 'x', budgeted: 1000, activity: 0, balance: 1000 }),
+      ]);
+
+      const result = await tool.execute({ budget_id: 'test-budget' });
+      const group = result.category_groups[0] as Record<string, unknown>;
+
+      expect('deleted' in group).toBe(false);
+    });
+
+    it('omits note key when note is null or empty', async () => {
+      setupWithCategories([
+        createMockCategory({ id: 'c1', name: 'A', budgeted: 1000, activity: 0, balance: 1000, note: null }),
+        createMockCategory({ id: 'c2', name: 'B', budgeted: 1000, activity: 0, balance: 1000, note: '' }),
+      ]);
+
+      const result = await tool.execute({ budget_id: 'test-budget' });
+
+      for (const cat of result.category_groups[0]!.categories) {
+        expect('note' in cat).toBe(false);
+      }
+    });
+
+    it('keeps note when present', async () => {
+      setupWithCategories([
+        createMockCategory({ id: 'c1', name: 'A', budgeted: 1000, activity: 0, balance: 1000, note: 'keep me' }),
+      ]);
+
+      const result = await tool.execute({ budget_id: 'test-budget' });
+
+      expect(result.category_groups[0]!.categories[0]!.note).toBe('keep me');
+    });
+
+    it('drops empty groups after filtering', async () => {
+      const populatedGroup = createMockCategoryGroup(0, { id: 'g-pop', name: 'Populated' });
+      populatedGroup.categories = [
+        createMockCategory({ id: 'active', name: 'Active', budgeted: 100000, activity: 0, balance: 100000 }),
+      ];
+      const emptyGroup = createMockCategoryGroup(0, { id: 'g-empty', name: 'OnlyZeros' });
+      emptyGroup.categories = [
+        createMockCategory({ id: 'zero', name: 'Zero', budgeted: 0, activity: 0, balance: 0 }),
+      ];
+      client.getCategories.mockResolvedValue({
+        category_groups: [populatedGroup, emptyGroup],
+        server_knowledge: 1,
+      });
+
+      const result = await tool.execute({ budget_id: 'test-budget' });
+
+      expect(result.category_groups).toHaveLength(1);
+      expect(result.category_groups[0]!.id).toBe('g-pop');
+    });
+
+    it('excludes deleted groups always (including "all" filter)', async () => {
+      const live = createMockCategoryGroup(0, { id: 'live', name: 'Live', deleted: false });
+      live.categories = [
+        createMockCategory({ id: 'c1', name: 'A', budgeted: 1000, activity: 0, balance: 1000 }),
+      ];
+      const gone = createMockCategoryGroup(0, { id: 'gone', name: 'Deleted', deleted: true });
+      gone.categories = [
+        createMockCategory({ id: 'c2', name: 'B', budgeted: 1000, activity: 0, balance: 1000 }),
+      ];
+      client.getCategories.mockResolvedValue({
+        category_groups: [live, gone],
+        server_knowledge: 1,
+      });
+
+      for (const filter of ['active', 'with_activity', 'with_balance', 'all'] as const) {
+        const result = await tool.execute({ budget_id: 'test-budget', category_filter: filter });
+        const ids = result.category_groups.map(g => g.id);
+        expect(ids).not.toContain('gone');
+      }
+    });
+  });
+
+  describe('category_filter', () => {
+    const cats = () => [
+      createMockCategory({ id: 'budgeted-only', name: 'Pre-funded', budgeted: 100000, activity: 0, balance: 100000 }),
+      createMockCategory({ id: 'activity-only', name: 'Spent', budgeted: 0, activity: -50000, balance: -50000 }),
+      createMockCategory({ id: 'balance-only', name: 'Carryover', budgeted: 0, activity: 0, balance: 25000 }),
+      createMockCategory({ id: 'zero', name: 'Dormant', budgeted: 0, activity: 0, balance: 0 }),
+    ];
+
+    function setup() {
+      const c = cats();
+      const group = createMockCategoryGroup(0, { id: 'g1', name: 'G' });
+      group.categories = c;
+      client.getCategories.mockResolvedValue({ category_groups: [group], server_knowledge: 1 });
+    }
+
+    it('active (default) includes budgeted/activity/balance non-zero, excludes dormant', async () => {
+      setup();
+      const result = await tool.execute({ budget_id: 'b' });
+      const ids = result.category_groups[0]!.categories.map(c => c.id);
+      expect(ids).toEqual(['budgeted-only', 'activity-only', 'balance-only']);
+    });
+
+    it('with_activity includes only activity != 0', async () => {
+      setup();
+      const result = await tool.execute({ budget_id: 'b', category_filter: 'with_activity' });
+      const ids = result.category_groups[0]!.categories.map(c => c.id);
+      expect(ids).toEqual(['activity-only']);
+    });
+
+    it('with_balance includes only balance != 0', async () => {
+      setup();
+      const result = await tool.execute({ budget_id: 'b', category_filter: 'with_balance' });
+      const ids = result.category_groups[0]!.categories.map(c => c.id);
+      expect(ids).toEqual(['budgeted-only', 'activity-only', 'balance-only']);
+    });
+
+    it('all includes every category including dormant', async () => {
+      setup();
+      const result = await tool.execute({ budget_id: 'b', category_filter: 'all' });
+      const ids = result.category_groups[0]!.categories.map(c => c.id);
+      expect(ids).toEqual(['budgeted-only', 'activity-only', 'balance-only', 'zero']);
+    });
+
+    it('rejects invalid category_filter', async () => {
+      setup();
+      await expect(tool.execute({ budget_id: 'b', category_filter: 'bogus' })).rejects.toThrow();
+    });
+
+    it('excludes deleted categories from every filter mode (including "all")', async () => {
+      // Live category needs non-zero across all three to survive every filter mode
+      const live = createMockCategory({ id: 'live', name: 'Live', budgeted: 100000, activity: -50000, balance: 50000, deleted: false });
+      const gone = createMockCategory({ id: 'gone', name: 'Deleted', budgeted: 50000, activity: -25000, balance: 25000, deleted: true });
+
+      for (const filter of ['active', 'with_activity', 'with_balance', 'all'] as const) {
+        const group = createMockCategoryGroup(0, { id: 'g1', name: 'G' });
+        group.categories = [live, gone];
+        client.getCategories.mockResolvedValue({ category_groups: [group], server_knowledge: 1 });
+
+        const result = await tool.execute({ budget_id: 'b', category_filter: filter });
+        const ids = result.category_groups[0]!.categories.map(c => c.id);
+        expect(ids).not.toContain('gone');
+      }
+    });
+  });
 });
 
 describe('GetCategoryTool', () => {


### PR DESCRIPTION
## Summary
- `ynab_get_categories` now returns **active categories only by default** and drops goal metadata, `original_category_group_id`, and `deleted` from the response. New `category_filter: active | with_activity | with_balance | all` matches the precedent set by `ynab_get_budget_month` in v2.0.0.
- Category amounts now use `{milliunits, formatted}` (consistent with every other tool). Before, the tool returned raw milliunit integers for budgeted/activity/balance and nested `{milliunits, formatted}` for the goal_* fields — inconsistent.
- Empty groups are dropped from the response after filtering.
- Deleted groups and categories are always excluded regardless of `category_filter`.
- **Breaking response-shape change → v3.0.0.**

Motivation: a ~200KB payload on a real budget blew past the harness token limit; with `active` default the same call returns a handful of KB.

Also pulled in two pre-existing unstaged doc updates that belonged with prior releases (v2.0.0 budget-month trim notes + the Budgeting Automation section covering the 7 tools from #19/#23/#24/#25). These were sitting as uncommitted in main; rolling them in here so main goes back to clean.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] `npm test` — 501 tests pass (14 new covering trim behavior, goal stripping, empty-group drop, and all four `category_filter` values including deleted-category exclusion)
- [ ] Manual against real budget: `ynab_get_categories` default + each filter — confirm payload size drop.