### PR TITLE
Allow Dependabot Claude reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,6 +27,9 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true
           display_report: true
+          # Allow GitHub Dependabot security/dependency PRs to receive automated review.
+          # Keep this narrow: do not use "*" unless we intentionally trust all bots.
+          allowed_bots: "dependabot"
           additional_permissions: |
             actions: read
           prompt: |


### PR DESCRIPTION
## Summary
- allow Dependabot-authored PRs to run the Claude Code Review workflow
- keep the bot allowlist narrow by using `dependabot`, not `*`

## Why
Dependabot security/dependency PRs currently fail Claude review during the prepare step with:

Workflow initiated by non-human actor: dependabot (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.

## Verification
- inspected failing Actions logs for Dependabot PRs
- workflow-only YAML change
