### PR TITLE
fix: update uuid dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ynab-mcp-server",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ynab-mcp-server",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.4",
@@ -19,7 +19,6 @@
       },
       "devDependencies": {
         "@types/node": "^24.3.0",
-        "@types/uuid": "^10.0.0",
         "tsx": "^4.20.5",
         "typescript": "^5.9.2",
         "vitest": "^3.2.4"
@@ -912,13 +911,6 @@
       "dependencies": {
         "undici-types": "~7.10.0"
       }
-    },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
@@ -2227,9 +2219,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@modelcontextprotocol/sdk": "^1.17.4",
         "axios": "^1.11.0",
         "dotenv": "^17.2.1",
-        "uuid": "^10.0.0",
+        "uuid": "^14.0.0",
         "yaml": "^2.8.3",
         "zod": "^3.25.76",
         "zod-to-json-schema": "^3.25.1"
@@ -2683,16 +2683,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@modelcontextprotocol/sdk": "^1.17.4",
     "axios": "^1.11.0",
     "dotenv": "^17.2.1",
-    "uuid": "^10.0.0",
+    "uuid": "^14.0.0",
     "yaml": "^2.8.3",
     "zod": "^3.25.76",
     "zod-to-json-schema": "^3.25.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ynab-mcp-server",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Comprehensive Model Context Protocol server providing intelligent access to YNAB (You Need A Budget) data with AI-powered budget recommendations, spending analysis, and complete transaction management",
   "type": "module",
   "main": "dist/index.js",
@@ -75,7 +75,6 @@
   },
   "devDependencies": {
     "@types/node": "^24.3.0",
-    "@types/uuid": "^10.0.0",
     "tsx": "^4.20.5",
     "typescript": "^5.9.2",
     "vitest": "^3.2.4"


### PR DESCRIPTION
## Summary
- Updates `uuid` from `^10.0.0` to `^14.0.0`.
- Clears the local production npm audit advisory GHSA-w5hq-g745-h8pq (`uuid < 11.1.1`).
- Code imports only `v4` from `uuid`, which remains supported by the current ESM API.

## Verification
- `npm audit --omit=dev` -> 0 vulnerabilities
- `npm run lint` -> passed
- `npm test -- --run` -> passed, 36 files / 504 tests passed / 2 skipped
- `npm run build` -> passed

## Notes
- No GitHub Dependabot alert was visible for this repo at sweep time, but the production audit found the moderate direct dependency advisory.
