### PR TITLE
fix: update hono lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1784,9 +1784,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
## Summary
- Updates the lockfile-resolved `hono` transitive dependency from 4.12.18 to 4.12.23.
- Clears the open GitHub Dependabot Hono advisory cluster while preserving the existing dependency constraints.
- Supersedes Dependabot PR #33, whose lockfile was not accepted by CI (`npm ci` reported package-lock/package.json sync errors around esbuild optional packages).

## Verification
- npm ci: passed
- npm audit --json: 0 vulnerabilities
- npm run lint: passed
- npm test -- --run: passed
- npm run build: passed

## Notes
- This is intentionally lockfile-only and scoped to the Hono security alerts.
